### PR TITLE
Add participant compliance data and event assignment workflows

### DIFF
--- a/age_categories.php
+++ b/age_categories.php
@@ -1,0 +1,170 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+require_login();
+require_role(['super_admin']);
+
+$db = get_db_connection();
+$errors = [];
+$edit_category = null;
+
+if (is_post()) {
+    $action = post_param('action');
+    if ($action === 'create' || $action === 'update') {
+        $data = [
+            'name' => trim((string) post_param('name', '')),
+            'min_age' => post_param('min_age') !== null && post_param('min_age') !== '' ? (int) post_param('min_age') : null,
+            'max_age' => post_param('max_age') !== null && post_param('max_age') !== '' ? (int) post_param('max_age') : null,
+        ];
+
+        validate_required(['name' => 'Category name'], $errors, $data);
+
+        if ($data['min_age'] !== null && $data['min_age'] < 0) {
+            $errors['min_age'] = 'Minimum age must be zero or greater.';
+        }
+        if ($data['max_age'] !== null && $data['max_age'] < 0) {
+            $errors['max_age'] = 'Maximum age must be zero or greater.';
+        }
+        if ($data['min_age'] !== null && $data['max_age'] !== null && $data['min_age'] > $data['max_age']) {
+            $errors['max_age'] = 'Maximum age must be greater than or equal to minimum age.';
+        }
+
+        if (!$errors) {
+            if ($action === 'create') {
+                $stmt = $db->prepare('INSERT INTO age_categories (name, min_age, max_age) VALUES (?, ?, ?)');
+                $stmt->bind_param('sii', $data['name'], $data['min_age'], $data['max_age']);
+                $stmt->execute();
+                $stmt->close();
+                set_flash('success', 'Age category created successfully.');
+            } else {
+                $category_id = (int) post_param('id');
+                $stmt = $db->prepare('UPDATE age_categories SET name = ?, min_age = ?, max_age = ?, updated_at = NOW() WHERE id = ?');
+                $stmt->bind_param('siii', $data['name'], $data['min_age'], $data['max_age'], $category_id);
+                $stmt->execute();
+                $stmt->close();
+                set_flash('success', 'Age category updated successfully.');
+            }
+            redirect('age_categories.php');
+        }
+
+        $edit_category = $data;
+        $edit_category['id'] = (int) post_param('id');
+    } elseif ($action === 'delete') {
+        $category_id = (int) post_param('id');
+        $stmt = $db->prepare('DELETE FROM age_categories WHERE id = ?');
+        $stmt->bind_param('i', $category_id);
+        if ($stmt->execute()) {
+            set_flash('success', 'Age category removed.');
+        } else {
+            set_flash('error', 'Unable to delete age category. Remove dependent records first.');
+        }
+        $stmt->close();
+        redirect('age_categories.php');
+    }
+}
+
+if (!$edit_category && ($edit_id = (int) get_param('edit', 0))) {
+    $stmt = $db->prepare('SELECT * FROM age_categories WHERE id = ?');
+    $stmt->bind_param('i', $edit_id);
+    $stmt->execute();
+    $edit_category = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+
+$result = $db->query('SELECT * FROM age_categories ORDER BY COALESCE(min_age, 0), name');
+$categories = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+$result?->close();
+
+$flash_success = get_flash('success');
+$flash_error = get_flash('error');
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0">Age Categories</h1>
+        <p class="text-muted mb-0">Maintain age brackets available for event registrations.</p>
+    </div>
+</div>
+<?php if ($flash_success): ?>
+    <div class="alert alert-success"><?php echo sanitize($flash_success); ?></div>
+<?php endif; ?>
+<?php if ($flash_error): ?>
+    <div class="alert alert-danger"><?php echo sanitize($flash_error); ?></div>
+<?php endif; ?>
+<div class="row g-4">
+    <div class="col-lg-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-white">
+                <h2 class="h6 mb-0"><?php echo $edit_category ? 'Edit Age Category' : 'Add Age Category'; ?></h2>
+            </div>
+            <div class="card-body">
+                <form method="post">
+                    <input type="hidden" name="action" value="<?php echo $edit_category ? 'update' : 'create'; ?>">
+                    <input type="hidden" name="id" value="<?php echo (int) ($edit_category['id'] ?? 0); ?>">
+                    <div class="mb-3">
+                        <label for="name" class="form-label">Category Name</label>
+                        <input type="text" class="form-control <?php echo isset($errors['name']) ? 'is-invalid' : ''; ?>" id="name" name="name" value="<?php echo sanitize($edit_category['name'] ?? ''); ?>" required>
+                        <?php if (isset($errors['name'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['name']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="min_age" class="form-label">Minimum Age</label>
+                        <input type="number" min="0" class="form-control <?php echo isset($errors['min_age']) ? 'is-invalid' : ''; ?>" id="min_age" name="min_age" value="<?php echo isset($edit_category['min_age']) && $edit_category['min_age'] !== null ? (int) $edit_category['min_age'] : ''; ?>">
+                        <?php if (isset($errors['min_age'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['min_age']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="max_age" class="form-label">Maximum Age</label>
+                        <input type="number" min="0" class="form-control <?php echo isset($errors['max_age']) ? 'is-invalid' : ''; ?>" id="max_age" name="max_age" value="<?php echo isset($edit_category['max_age']) && $edit_category['max_age'] !== null ? (int) $edit_category['max_age'] : ''; ?>">
+                        <?php if (isset($errors['max_age'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['max_age']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="d-grid gap-2">
+                        <button type="submit" class="btn btn-primary"><?php echo $edit_category ? 'Update Category' : 'Create Category'; ?></button>
+                        <?php if ($edit_category): ?>
+                            <a href="age_categories.php" class="btn btn-outline-secondary">Cancel</a>
+                        <?php endif; ?>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-8">
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Minimum Age</th>
+                                <th>Maximum Age</th>
+                                <th class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($categories as $category): ?>
+                            <tr>
+                                <td><?php echo sanitize($category['name']); ?></td>
+                                <td><?php echo $category['min_age'] !== null ? (int) $category['min_age'] : '<span class="text-muted">Any</span>'; ?></td>
+                                <td><?php echo $category['max_age'] !== null ? (int) $category['max_age'] : '<span class="text-muted">Any</span>'; ?></td>
+                                <td class="text-end">
+                                    <div class="table-actions justify-content-end">
+                                        <a href="age_categories.php?edit=<?php echo (int) $category['id']; ?>" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil"></i></a>
+                                        <form method="post" onsubmit="return confirm('Delete this age category?');">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?php echo (int) $category['id']; ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$categories): ?>
+                            <tr>
+                                <td colspan="4" class="text-center text-muted py-4">No age categories defined.</td>
+                            </tr>
+                        <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/event_master.php
+++ b/event_master.php
@@ -1,0 +1,270 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+require_login();
+require_role(['super_admin']);
+
+$db = get_db_connection();
+$errors = [];
+$edit_event_master = null;
+
+if (is_post()) {
+    $action = post_param('action');
+    if ($action === 'create' || $action === 'update') {
+        $data = [
+            'event_id' => (int) post_param('event_id'),
+            'age_category_id' => (int) post_param('age_category_id'),
+            'code' => trim((string) post_param('code', '')),
+            'name' => trim((string) post_param('name', '')),
+            'gender' => post_param('gender'),
+            'event_type' => post_param('event_type'),
+            'fees' => post_param('fees') !== null && post_param('fees') !== '' ? (float) post_param('fees') : null,
+            'label' => trim((string) post_param('label', '')),
+        ];
+
+        if ($data['label'] === '') {
+            $data['label'] = null;
+        }
+
+        validate_required([
+            'event_id' => 'Event',
+            'age_category_id' => 'Age category',
+            'code' => 'Event code',
+            'name' => 'Event name',
+            'gender' => 'Gender',
+            'event_type' => 'Event type',
+        ], $errors, $data);
+
+        if ($data['fees'] === null || $data['fees'] < 0) {
+            $errors['fees'] = 'Fees must be zero or a positive amount.';
+        }
+
+        if ($data['gender'] && !in_array($data['gender'], ['Male', 'Female', 'Open'], true)) {
+            $errors['gender'] = 'Invalid gender selection.';
+        }
+
+        if ($data['event_type'] && !in_array($data['event_type'], ['Individual', 'Team', 'Institution'], true)) {
+            $errors['event_type'] = 'Invalid event type selection.';
+        }
+
+        if (!$errors) {
+            if ($action === 'create') {
+                $stmt = $db->prepare('INSERT INTO event_master (event_id, age_category_id, code, name, gender, event_type, fees, label) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+                $stmt->bind_param('iissssds', $data['event_id'], $data['age_category_id'], $data['code'], $data['name'], $data['gender'], $data['event_type'], $data['fees'], $data['label']);
+                if ($stmt->execute()) {
+                    set_flash('success', 'Event entry created successfully.');
+                    $stmt->close();
+                    redirect('event_master.php');
+                }
+                if ($stmt->errno === 1062) {
+                    $errors['code'] = 'This event code is already in use for the selected event.';
+                } else {
+                    $errors['general'] = 'Unable to save event entry. Please try again.';
+                }
+                $stmt->close();
+            } else {
+                $event_master_id = (int) post_param('id');
+                $stmt = $db->prepare('UPDATE event_master SET event_id = ?, age_category_id = ?, code = ?, name = ?, gender = ?, event_type = ?, fees = ?, label = ?, updated_at = NOW() WHERE id = ?');
+                $stmt->bind_param('iissssdsi', $data['event_id'], $data['age_category_id'], $data['code'], $data['name'], $data['gender'], $data['event_type'], $data['fees'], $data['label'], $event_master_id);
+                if ($stmt->execute()) {
+                    set_flash('success', 'Event entry updated successfully.');
+                    $stmt->close();
+                    redirect('event_master.php');
+                }
+                if ($stmt->errno === 1062) {
+                    $errors['code'] = 'This event code is already in use for the selected event.';
+                } else {
+                    $errors['general'] = 'Unable to update event entry. Please try again.';
+                }
+                $stmt->close();
+            }
+        }
+
+        $edit_event_master = $data;
+        $edit_event_master['id'] = (int) post_param('id');
+    } elseif ($action === 'delete') {
+        $event_master_id = (int) post_param('id');
+        $stmt = $db->prepare('DELETE FROM event_master WHERE id = ?');
+        $stmt->bind_param('i', $event_master_id);
+        if ($stmt->execute()) {
+            set_flash('success', 'Event entry removed.');
+        } else {
+            set_flash('error', 'Unable to delete event entry. Remove linked participant events first.');
+        }
+        $stmt->close();
+        redirect('event_master.php');
+    }
+}
+
+if (!$edit_event_master && ($edit_id = (int) get_param('edit', 0))) {
+    $stmt = $db->prepare('SELECT * FROM event_master WHERE id = ?');
+    $stmt->bind_param('i', $edit_id);
+    $stmt->execute();
+    $edit_event_master = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+
+$events_result = $db->query('SELECT id, name FROM events ORDER BY name');
+$events = $events_result ? $events_result->fetch_all(MYSQLI_ASSOC) : [];
+$events_result?->close();
+
+$age_result = $db->query('SELECT id, name FROM age_categories ORDER BY name');
+$age_categories = $age_result ? $age_result->fetch_all(MYSQLI_ASSOC) : [];
+$age_result?->close();
+
+$stmt = $db->prepare('SELECT em.*, e.name AS event_name, ac.name AS age_category_name FROM event_master em JOIN events e ON e.id = em.event_id JOIN age_categories ac ON ac.id = em.age_category_id ORDER BY e.name, em.name');
+$stmt->execute();
+$event_entries = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$flash_success = get_flash('success');
+$flash_error = get_flash('error');
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0">Event Master</h1>
+        <p class="text-muted mb-0">Define the individual competitions available within each event.</p>
+    </div>
+</div>
+<?php if ($flash_success): ?>
+    <div class="alert alert-success"><?php echo sanitize($flash_success); ?></div>
+<?php endif; ?>
+<?php if ($flash_error): ?>
+    <div class="alert alert-danger"><?php echo sanitize($flash_error); ?></div>
+<?php endif; ?>
+<div class="row g-4">
+    <div class="col-lg-5">
+        <div class="card shadow-sm">
+            <div class="card-header bg-white">
+                <h2 class="h6 mb-0"><?php echo $edit_event_master ? 'Edit Event Entry' : 'Add Event Entry'; ?></h2>
+            </div>
+            <div class="card-body">
+                <?php if (isset($errors['general'])): ?>
+                    <div class="alert alert-danger"><?php echo sanitize($errors['general']); ?></div>
+                <?php endif; ?>
+                <form method="post">
+                    <input type="hidden" name="action" value="<?php echo $edit_event_master ? 'update' : 'create'; ?>">
+                    <input type="hidden" name="id" value="<?php echo (int) ($edit_event_master['id'] ?? 0); ?>">
+                    <div class="mb-3">
+                        <label for="event_id" class="form-label">Event</label>
+                        <select class="form-select <?php echo isset($errors['event_id']) ? 'is-invalid' : ''; ?>" id="event_id" name="event_id" required>
+                            <option value="">Select Event</option>
+                            <?php foreach ($events as $event): ?>
+                                <option value="<?php echo (int) $event['id']; ?>" <?php echo isset($edit_event_master['event_id']) && (int) $edit_event_master['event_id'] === (int) $event['id'] ? 'selected' : ''; ?>><?php echo sanitize($event['name']); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <?php if (isset($errors['event_id'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['event_id']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="age_category_id" class="form-label">Age Category</label>
+                        <select class="form-select <?php echo isset($errors['age_category_id']) ? 'is-invalid' : ''; ?>" id="age_category_id" name="age_category_id" required>
+                            <option value="">Select Age Category</option>
+                            <?php foreach ($age_categories as $category): ?>
+                                <option value="<?php echo (int) $category['id']; ?>" <?php echo isset($edit_event_master['age_category_id']) && (int) $edit_event_master['age_category_id'] === (int) $category['id'] ? 'selected' : ''; ?>><?php echo sanitize($category['name']); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <?php if (isset($errors['age_category_id'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['age_category_id']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="code" class="form-label">Event Code</label>
+                        <input type="text" class="form-control <?php echo isset($errors['code']) ? 'is-invalid' : ''; ?>" id="code" name="code" value="<?php echo sanitize($edit_event_master['code'] ?? ''); ?>" required>
+                        <?php if (isset($errors['code'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['code']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="name" class="form-label">Event Name</label>
+                        <input type="text" class="form-control <?php echo isset($errors['name']) ? 'is-invalid' : ''; ?>" id="name" name="name" value="<?php echo sanitize($edit_event_master['name'] ?? ''); ?>" required>
+                        <?php if (isset($errors['name'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['name']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="gender" class="form-label">Gender</label>
+                        <select class="form-select <?php echo isset($errors['gender']) ? 'is-invalid' : ''; ?>" id="gender" name="gender" required>
+                            <option value="">Select Gender</option>
+                            <?php foreach (['Male', 'Female', 'Open'] as $gender): ?>
+                                <option value="<?php echo $gender; ?>" <?php echo isset($edit_event_master['gender']) && $edit_event_master['gender'] === $gender ? 'selected' : ''; ?>><?php echo $gender; ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <?php if (isset($errors['gender'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['gender']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="event_type" class="form-label">Event Type</label>
+                        <select class="form-select <?php echo isset($errors['event_type']) ? 'is-invalid' : ''; ?>" id="event_type" name="event_type" required>
+                            <option value="">Select Type</option>
+                            <?php foreach (['Individual', 'Team', 'Institution'] as $type): ?>
+                                <option value="<?php echo $type; ?>" <?php echo isset($edit_event_master['event_type']) && $edit_event_master['event_type'] === $type ? 'selected' : ''; ?>><?php echo $type; ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <?php if (isset($errors['event_type'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['event_type']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="fees" class="form-label">Event Fees</label>
+                        <input type="number" step="0.01" min="0" class="form-control <?php echo isset($errors['fees']) ? 'is-invalid' : ''; ?>" id="fees" name="fees" value="<?php echo isset($edit_event_master['fees']) && $edit_event_master['fees'] !== null ? (float) $edit_event_master['fees'] : '0'; ?>" required>
+                        <?php if (isset($errors['fees'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['fees']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="label" class="form-label">Event Label</label>
+                        <input type="text" class="form-control" id="label" name="label" value="<?php echo sanitize($edit_event_master['label'] ?? ''); ?>" placeholder="Optional label or category">
+                    </div>
+                    <div class="d-grid gap-2">
+                        <button type="submit" class="btn btn-primary"><?php echo $edit_event_master ? 'Update Event Entry' : 'Create Event Entry'; ?></button>
+                        <?php if ($edit_event_master): ?>
+                            <a href="event_master.php" class="btn btn-outline-secondary">Cancel</a>
+                        <?php endif; ?>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-7">
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>Code</th>
+                                <th>Event</th>
+                                <th>Label</th>
+                                <th>Gender</th>
+                                <th>Age Category</th>
+                                <th>Type</th>
+                                <th class="text-end">Fees</th>
+                                <th class="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($event_entries as $entry): ?>
+                            <tr>
+                                <td class="fw-semibold"><?php echo sanitize($entry['code']); ?></td>
+                                <td>
+                                    <div class="fw-semibold"><?php echo sanitize($entry['name']); ?></div>
+                                    <div class="text-muted small">Event: <?php echo sanitize($entry['event_name']); ?></div>
+                                </td>
+                                <td><?php echo $entry['label'] ? sanitize($entry['label']) : '<span class="text-muted">-</span>'; ?></td>
+                                <td><?php echo sanitize($entry['gender']); ?></td>
+                                <td><?php echo sanitize($entry['age_category_name']); ?></td>
+                                <td><?php echo sanitize($entry['event_type']); ?></td>
+                                <td class="text-end">₹<?php echo number_format((float) $entry['fees'], 2); ?></td>
+                                <td class="text-end">
+                                    <div class="table-actions justify-content-end">
+                                        <a href="event_master.php?edit=<?php echo (int) $entry['id']; ?>" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil"></i></a>
+                                        <form method="post" onsubmit="return confirm('Delete this event entry?');">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?php echo (int) $entry['id']; ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$event_entries): ?>
+                            <tr>
+                                <td colspan="8" class="text-center text-muted py-4">No event entries found.</td>
+                            </tr>
+                        <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -14,6 +14,8 @@
                 <li class="nav-item"><a class="nav-link" href="dashboard.php">Dashboard</a></li>
                 <?php if ($user['role'] === 'super_admin'): ?>
                     <li class="nav-item"><a class="nav-link" href="events.php">Events</a></li>
+                    <li class="nav-item"><a class="nav-link" href="age_categories.php">Age Categories</a></li>
+                    <li class="nav-item"><a class="nav-link" href="event_master.php">Event Master</a></li>
                     <li class="nav-item"><a class="nav-link" href="event_admins.php">Event Admins</a></li>
                 <?php endif; ?>
                 <?php if ($user['role'] === 'event_admin'): ?>

--- a/participant_events.php
+++ b/participant_events.php
@@ -1,0 +1,320 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+require_login();
+require_role(['institution_admin', 'event_admin', 'event_staff', 'super_admin']);
+
+$user = current_user();
+$db = get_db_connection();
+$role = $user['role'];
+$can_manage = $role === 'institution_admin';
+
+$event_id = null;
+$institution_id = null;
+$institution_context = null;
+
+if ($role === 'institution_admin') {
+    if (!$user['institution_id']) {
+        echo '<div class="alert alert-warning">No institution assigned to your account. Please contact the event administrator.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+    $institution_id = (int) $user['institution_id'];
+    $stmt = $db->prepare('SELECT id, name, event_id FROM institutions WHERE id = ?');
+    $stmt->bind_param('i', $institution_id);
+    $stmt->execute();
+    $institution_context = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if (!$institution_context) {
+        echo '<div class="alert alert-danger">Unable to load institution information.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+    $event_id = (int) $institution_context['event_id'];
+} elseif ($role === 'event_admin' || $role === 'event_staff') {
+    if (!$user['event_id']) {
+        echo '<div class="alert alert-warning">No event assigned to your account. Please contact the super administrator.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+    $event_id = (int) $user['event_id'];
+    $institution_id = (int) get_param('institution_id', 0) ?: null;
+} else {
+    $event_id = (int) get_param('event_id', 0) ?: null;
+    $institution_id = (int) get_param('institution_id', 0) ?: null;
+}
+
+$participant_id = (int) get_param('participant_id', 0);
+if (!$participant_id) {
+    echo '<div class="alert alert-warning">Participant not specified.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+function load_participant_with_access(mysqli $db, int $participant_id, ?int $institution_id, ?int $event_id, string $role): ?array
+{
+    $sql = 'SELECT p.*, i.name AS institution_name FROM participants p INNER JOIN institutions i ON i.id = p.institution_id WHERE p.id = ?';
+    $params = [$participant_id];
+    $types = 'i';
+
+    if ($institution_id) {
+        $sql .= ' AND p.institution_id = ?';
+        $params[] = $institution_id;
+        $types .= 'i';
+    }
+
+    if ($role === 'event_admin' || $role === 'event_staff') {
+        $sql .= ' AND p.event_id = ?';
+        $params[] = $event_id;
+        $types .= 'i';
+    } elseif ($role === 'super_admin') {
+        if ($event_id) {
+            $sql .= ' AND p.event_id = ?';
+            $params[] = $event_id;
+            $types .= 'i';
+        }
+        if ($institution_id) {
+            $sql .= ' AND p.institution_id = ?';
+            $params[] = $institution_id;
+            $types .= 'i';
+        }
+    }
+
+    $stmt = $db->prepare($sql);
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $participant = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    return $participant ?: null;
+}
+
+$participant = load_participant_with_access($db, $participant_id, $institution_id, $event_id, $role);
+if (!$participant) {
+    echo '<div class="alert alert-danger">Unable to load participant details or insufficient permissions.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$can_manage_events = $can_manage && $participant['status'] === 'draft';
+
+$dob = new DateTime($participant['date_of_birth']);
+$age = $dob->diff(new DateTime())->y;
+
+if (is_post()) {
+    $action = post_param('action');
+    if ($action === 'add') {
+        if (!$can_manage_events) {
+            set_flash('error', 'You cannot modify events for this participant.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        $event_master_id = (int) post_param('event_master_id');
+        if (!$event_master_id) {
+            set_flash('error', 'Select an event to add.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        $stmt = $db->prepare('SELECT em.*, ac.min_age, ac.max_age FROM event_master em JOIN age_categories ac ON ac.id = em.age_category_id WHERE em.id = ? AND em.event_id = ?');
+        $stmt->bind_param('ii', $event_master_id, $participant['event_id']);
+        $stmt->execute();
+        $event_entry = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if (!$event_entry) {
+            set_flash('error', 'Invalid event selection.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        if ($event_entry['gender'] !== 'Open' && $event_entry['gender'] !== $participant['gender']) {
+            set_flash('error', 'Selected event is not available for this participant.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        if ($event_entry['min_age'] !== null && $age < (int) $event_entry['min_age']) {
+            set_flash('error', 'Participant does not meet the minimum age for this event.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        if ($event_entry['max_age'] !== null && $age > (int) $event_entry['max_age']) {
+            set_flash('error', 'Participant exceeds the maximum age for this event.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        $stmt = $db->prepare('SELECT id FROM participant_events WHERE participant_id = ? AND event_master_id = ?');
+        $stmt->bind_param('ii', $participant_id, $event_master_id);
+        $stmt->execute();
+        $exists = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if ($exists) {
+            set_flash('error', 'This event is already assigned to the participant.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        $stmt = $db->prepare('INSERT INTO participant_events (participant_id, event_master_id, institution_id, fees) VALUES (?, ?, ?, ?)');
+        $fees = (float) $event_entry['fees'];
+        $stmt->bind_param('iiid', $participant_id, $event_master_id, $participant['institution_id'], $fees);
+        $stmt->execute();
+        $stmt->close();
+        set_flash('success', 'Event added to participant successfully.');
+        redirect('participant_events.php?participant_id=' . $participant_id);
+    } elseif ($action === 'delete') {
+        if (!$can_manage_events) {
+            set_flash('error', 'You cannot modify events for this participant.');
+            redirect('participant_events.php?participant_id=' . $participant_id);
+        }
+        $assignment_id = (int) post_param('id');
+        $stmt = $db->prepare('DELETE FROM participant_events WHERE id = ? AND participant_id = ?');
+        $stmt->bind_param('ii', $assignment_id, $participant_id);
+        $stmt->execute();
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+        if ($affected) {
+            set_flash('success', 'Event removed from participant.');
+        } else {
+            set_flash('error', 'Unable to remove the selected event.');
+        }
+        redirect('participant_events.php?participant_id=' . $participant_id);
+    }
+}
+
+$stmt = $db->prepare('SELECT pe.id, pe.event_master_id, em.name, em.code, em.event_type, em.fees, em.label, ac.name AS age_category_name FROM participant_events pe JOIN event_master em ON em.id = pe.event_master_id JOIN age_categories ac ON ac.id = em.age_category_id WHERE pe.participant_id = ? ORDER BY em.name');
+$stmt->bind_param('i', $participant_id);
+$stmt->execute();
+$assigned_events = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$assigned_ids = array_map(static fn($row) => (int) $row['event_master_id'], $assigned_events);
+
+$stmt = $db->prepare('SELECT em.id, em.name, em.code, em.gender, em.event_type, em.fees, em.label, ac.name AS age_category_name, ac.min_age, ac.max_age FROM event_master em JOIN age_categories ac ON ac.id = em.age_category_id WHERE em.event_id = ? ORDER BY em.name');
+$stmt->bind_param('i', $participant['event_id']);
+$stmt->execute();
+$all_events = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$available_events = array_filter($all_events, static function ($event) use ($participant, $age, $assigned_ids) {
+    if (in_array((int) $event['id'], $assigned_ids, true)) {
+        return false;
+    }
+    if ($event['gender'] !== 'Open' && $event['gender'] !== $participant['gender']) {
+        return false;
+    }
+    if ($event['min_age'] !== null && $age < (int) $event['min_age']) {
+        return false;
+    }
+    if ($event['max_age'] !== null && $age > (int) $event['max_age']) {
+        return false;
+    }
+    return true;
+});
+
+$flash_success = get_flash('success');
+$flash_error = get_flash('error');
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0">Participant Events</h1>
+        <p class="text-muted mb-0">Assign competition entries to the participant.</p>
+    </div>
+    <a href="participants.php" class="btn btn-outline-secondary">Back to Participants</a>
+</div>
+<?php if ($flash_success): ?>
+    <div class="alert alert-success"><?php echo sanitize($flash_success); ?></div>
+<?php endif; ?>
+<?php if ($flash_error): ?>
+    <div class="alert alert-danger"><?php echo sanitize($flash_error); ?></div>
+<?php endif; ?>
+<?php if ($participant['status'] === 'submitted'): ?>
+    <div class="alert alert-info">This participant has been submitted. Event assignments are read-only.</div>
+<?php endif; ?>
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-md-4">
+                <div class="text-muted small">Participant</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['name']); ?></div>
+                <div class="text-muted small">Status: <span class="badge bg-<?php echo $participant['status'] === 'submitted' ? 'success' : 'secondary'; ?> text-uppercase"><?php echo sanitize($participant['status']); ?></span></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Date of Birth</div>
+                <div class="fw-semibold"><?php echo format_date($participant['date_of_birth']); ?> <span class="text-muted">(<?php echo (int) $age; ?> yrs)</span></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Gender</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['gender']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Institution</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['institution_name']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Aadhaar Number</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['aadhaar_number']); ?></div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="card shadow-sm">
+    <div class="card-body">
+        <h2 class="h6 mb-3">Assigned Events</h2>
+        <div class="table-responsive mb-4">
+            <table class="table table-striped align-middle">
+                <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Event Name</th>
+                        <th>Label</th>
+                        <th>Age Category</th>
+                        <th>Type</th>
+                        <th class="text-end">Fees</th>
+                        <?php if ($can_manage_events): ?><th class="text-end">Actions</th><?php endif; ?>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($assigned_events as $assigned): ?>
+                    <tr>
+                        <td class="fw-semibold"><?php echo sanitize($assigned['code']); ?></td>
+                        <td><?php echo sanitize($assigned['name']); ?></td>
+                        <td><?php echo $assigned['label'] ? sanitize($assigned['label']) : '<span class="text-muted">-</span>'; ?></td>
+                        <td><?php echo sanitize($assigned['age_category_name']); ?></td>
+                        <td><?php echo sanitize($assigned['event_type']); ?></td>
+                        <td class="text-end">₹<?php echo number_format((float) $assigned['fees'], 2); ?></td>
+                        <?php if ($can_manage_events): ?>
+                            <td class="text-end">
+                                <form method="post" onsubmit="return confirm('Remove this event from the participant?');">
+                                    <input type="hidden" name="action" value="delete">
+                                    <input type="hidden" name="id" value="<?php echo (int) $assigned['id']; ?>">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                                </form>
+                            </td>
+                        <?php endif; ?>
+                    </tr>
+                <?php endforeach; ?>
+                <?php if (!$assigned_events): ?>
+                    <tr>
+                        <td colspan="<?php echo $can_manage_events ? '7' : '6'; ?>" class="text-center text-muted py-4">No events assigned yet.</td>
+                    </tr>
+                <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php if ($can_manage_events): ?>
+            <form method="post" class="row g-2 align-items-end">
+                <input type="hidden" name="action" value="add">
+                <div class="col-md-9">
+                    <label for="event_master_id" class="form-label">Add Event</label>
+                    <select class="form-select" id="event_master_id" name="event_master_id" required>
+                        <option value="">Select an event</option>
+                        <?php foreach ($available_events as $option): ?>
+                            <option value="<?php echo (int) $option['id']; ?>">
+                                <?php echo sanitize($option['name']); ?> (<?php echo sanitize($option['code']); ?>)
+                                <?php if ($option['label']): ?> - <?php echo sanitize($option['label']); ?><?php endif; ?>
+                                <?php if ($option['age_category_name']): ?> - <?php echo sanitize($option['age_category_name']); ?><?php endif; ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-md-3 d-grid">
+                    <button type="submit" class="btn btn-primary" <?php echo $available_events ? '' : 'disabled'; ?>>Add Event</button>
+                </div>
+            </form>
+            <?php if (!$available_events): ?>
+                <p class="text-muted small mt-2">No additional events are available for this participant based on their age and gender.</p>
+            <?php endif; ?>
+        <?php else: ?>
+            <p class="text-muted mb-0">Event assignments can only be managed while the participant is in draft status by the institution admin.</p>
+        <?php endif; ?>
+    </div>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/schema.sql
+++ b/schema.sql
@@ -44,6 +44,32 @@ CREATE TABLE users (
     CONSTRAINT fk_user_institution FOREIGN KEY (institution_id) REFERENCES institutions(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE age_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    min_age TINYINT UNSIGNED DEFAULT NULL,
+    max_age TINYINT UNSIGNED DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE event_master (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    event_id INT NOT NULL,
+    age_category_id INT NOT NULL,
+    code VARCHAR(60) NOT NULL,
+    name VARCHAR(180) NOT NULL,
+    gender ENUM('Male', 'Female', 'Open') NOT NULL DEFAULT 'Open',
+    event_type ENUM('Individual', 'Team', 'Institution') NOT NULL,
+    fees DECIMAL(10,2) NOT NULL DEFAULT 0,
+    label VARCHAR(180),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_event_master_event FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+    CONSTRAINT fk_event_master_age FOREIGN KEY (age_category_id) REFERENCES age_categories(id) ON DELETE RESTRICT,
+    CONSTRAINT uq_event_master_code UNIQUE (event_id, code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE participants (
     id INT AUTO_INCREMENT PRIMARY KEY,
     institution_id INT NOT NULL,
@@ -55,6 +81,8 @@ CREATE TABLE participants (
     contact_number VARCHAR(50) NOT NULL,
     address TEXT,
     email VARCHAR(180),
+    aadhaar_number VARCHAR(20) NOT NULL,
+    photo_path VARCHAR(255) NOT NULL,
     status ENUM('draft', 'submitted') NOT NULL DEFAULT 'draft',
     created_by INT,
     submitted_by INT,
@@ -63,6 +91,19 @@ CREATE TABLE participants (
     submitted_at TIMESTAMP NULL,
     CONSTRAINT fk_participant_institution FOREIGN KEY (institution_id) REFERENCES institutions(id) ON DELETE CASCADE,
     CONSTRAINT fk_participant_event FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE participant_events (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    participant_id INT NOT NULL,
+    event_master_id INT NOT NULL,
+    institution_id INT NOT NULL,
+    fees DECIMAL(10,2) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_participant_event UNIQUE (participant_id, event_master_id),
+    CONSTRAINT fk_participant_events_participant FOREIGN KEY (participant_id) REFERENCES participants(id) ON DELETE CASCADE,
+    CONSTRAINT fk_participant_events_event FOREIGN KEY (event_master_id) REFERENCES event_master(id) ON DELETE CASCADE,
+    CONSTRAINT fk_participant_events_institution FOREIGN KEY (institution_id) REFERENCES institutions(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Default super administrator (password: admin123)

--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- capture Aadhaar numbers and passport photos for participants with secure upload handling and display updates
- introduce age category and event master management screens for super administrators with supporting schema tables
- allow institution admins to assign and remove event entries per participant via a dedicated management page and navigation links

## Testing
- php -l participants.php
- php -l age_categories.php
- php -l event_master.php
- php -l participant_events.php
- php -l includes/navbar.php

------
https://chatgpt.com/codex/tasks/task_e_68d2ddd7ffd48331ace46396efbd7e76