### PR TITLE
Add global footer with SportsbyA branding

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,5 +1,39 @@
+:root {
+    --color-light-grey: #f4f6f8;
+    --color-light-green: #c8e6c9;
+    --color-dark-blue: #0b3d62;
+}
+
 body {
     min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--color-light-grey);
+}
+
+main {
+    flex: 1 0 auto;
+}
+
+.site-footer {
+    background: linear-gradient(180deg, var(--color-light-grey) 0%, #ffffff 100%);
+    border-top: 4px solid var(--color-light-green);
+    color: var(--color-dark-blue);
+}
+
+.site-footer small {
+    letter-spacing: 0.03em;
+}
+
+.site-footer a {
+    color: var(--color-dark-blue);
+    text-decoration-color: var(--color-light-green);
+}
+
+.site-footer a:hover,
+.site-footer a:focus {
+    color: #062440;
+    text-decoration-color: var(--color-dark-blue);
 }
 
 .table-actions {

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,4 +1,11 @@
 </main>
+
+<footer class="site-footer mt-auto py-4">
+    <div class="container text-center">
+        <small class="fw-semibold">Copyright &copy; SportsbyA Tech Private Limited</small>
+    </div>
+</footer>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a global footer under the main content that shows the SportsbyA copyright notice
- introduce palette variables and layout tweaks so the footer keeps the light grey, green, and dark blue theme

## Testing
- php -l includes/footer.php

------
https://chatgpt.com/codex/tasks/task_e_68d34fb3f1b88331b8365f1c5aa872ad