### PR TITLE
Add dedicated change password page accessible from navbar

### DIFF
--- a/change_password.php
+++ b/change_password.php
@@ -1,0 +1,88 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+require_login();
+
+$user = current_user();
+$db = get_db_connection();
+$errors = [];
+$success = null;
+
+if (is_post()) {
+    $currentPassword = (string) post_param('current_password', '');
+    $newPassword = (string) post_param('password', '');
+    $confirmPassword = (string) post_param('confirm_password', '');
+
+    validate_required(
+        [
+            'current_password' => 'Current password',
+            'password' => 'New password',
+            'confirm_password' => 'Confirm password',
+        ],
+        $errors,
+        [
+            'current_password' => $currentPassword,
+            'password' => $newPassword,
+            'confirm_password' => $confirmPassword,
+        ]
+    );
+
+    if (!$errors && $newPassword !== $confirmPassword) {
+        $errors['confirm_password'] = 'Password confirmation does not match.';
+    }
+
+    if (!$errors) {
+        $stmt = $db->prepare('SELECT password_hash FROM users WHERE id = ? LIMIT 1');
+        $stmt->bind_param('i', $user['id']);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $record = $result->fetch_assoc();
+        $stmt->close();
+
+        if (!$record || !password_verify($currentPassword, $record['password_hash'])) {
+            $errors['current_password'] = 'Current password is incorrect.';
+        } else {
+            $hash = password_hash($newPassword, PASSWORD_DEFAULT);
+            $update = $db->prepare('UPDATE users SET password_hash = ? WHERE id = ?');
+            $update->bind_param('si', $hash, $user['id']);
+            $update->execute();
+            $update->close();
+            $success = 'Password updated successfully.';
+        }
+    }
+}
+?>
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-header bg-white">
+                <h1 class="h5 mb-0">Change Password</h1>
+            </div>
+            <div class="card-body">
+                <?php if ($success): ?>
+                    <div class="alert alert-success"><?php echo sanitize($success); ?></div>
+                <?php endif; ?>
+                <form method="post">
+                    <div class="mb-3">
+                        <label for="current_password" class="form-label">Current Password</label>
+                        <input type="password" class="form-control <?php echo isset($errors['current_password']) ? 'is-invalid' : ''; ?>" id="current_password" name="current_password" required>
+                        <?php if (isset($errors['current_password'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['current_password']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">New Password</label>
+                        <input type="password" class="form-control <?php echo isset($errors['password']) ? 'is-invalid' : ''; ?>" id="password" name="password" required>
+                        <?php if (isset($errors['password'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['password']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="mb-3">
+                        <label for="confirm_password" class="form-label">Confirm Password</label>
+                        <input type="password" class="form-control <?php echo isset($errors['confirm_password']) ? 'is-invalid' : ''; ?>" id="confirm_password" name="confirm_password" required>
+                        <?php if (isset($errors['confirm_password'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['confirm_password']); ?></div><?php endif; ?>
+                    </div>
+                    <div class="d-grid">
+                        <button type="submit" class="btn btn-primary">Update Password</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -41,6 +41,7 @@
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end shadow">
                     <li><a class="dropdown-item" href="profile.php">Profile</a></li>
+                    <li><a class="dropdown-item" href="change_password.php">Change Password</a></li>
                     <li><hr class="dropdown-divider"></li>
                     <li><a class="dropdown-item" href="logout.php">Logout</a></li>
                 </ul>

--- a/profile.php
+++ b/profile.php
@@ -10,23 +10,11 @@ $success = null;
 if (is_post()) {
     $name = trim(post_param('name', $user['name']));
     $contact = trim(post_param('contact_number', $user['contact_number'] ?? ''));
-    $password = (string) post_param('password', '');
-    $confirm = (string) post_param('confirm_password', '');
-
     validate_required(['name' => 'Name'], $errors, ['name' => $name]);
 
-    if ($password && $password !== $confirm) {
-        $errors['confirm_password'] = 'Password confirmation does not match.';
-    }
-
     if (!$errors) {
-        $stmt = $db->prepare('UPDATE users SET name = ?, contact_number = ?' . ($password ? ', password_hash = ?' : '') . ' WHERE id = ?');
-        if ($password) {
-            $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt->bind_param('sssi', $name, $contact, $hash, $user['id']);
-        } else {
-            $stmt->bind_param('ssi', $name, $contact, $user['id']);
-        }
+        $stmt = $db->prepare('UPDATE users SET name = ?, contact_number = ? WHERE id = ?');
+        $stmt->bind_param('ssi', $name, $contact, $user['id']);
         $stmt->execute();
         $stmt->close();
         $success = 'Profile updated successfully.';
@@ -58,16 +46,6 @@ if (is_post()) {
                     <div class="mb-3">
                         <label for="contact_number" class="form-label">Contact Number</label>
                         <input type="text" class="form-control" id="contact_number" name="contact_number" value="<?php echo sanitize($user['contact_number'] ?? ''); ?>">
-                    </div>
-                    <hr>
-                    <div class="mb-3">
-                        <label for="password" class="form-label">New Password</label>
-                        <input type="password" class="form-control" id="password" name="password" placeholder="Leave blank to keep current password">
-                    </div>
-                    <div class="mb-3">
-                        <label for="confirm_password" class="form-label">Confirm Password</label>
-                        <input type="password" class="form-control <?php echo isset($errors['confirm_password']) ? 'is-invalid' : ''; ?>" id="confirm_password" name="confirm_password">
-                        <?php if (isset($errors['confirm_password'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['confirm_password']); ?></div><?php endif; ?>
                     </div>
                     <div class="d-grid">
                         <button type="submit" class="btn btn-primary">Save Changes</button>


### PR DESCRIPTION
## Summary
- add a change password link to the authenticated user dropdown
- move the password update workflow into a dedicated change_password.php view with validation of current and new passwords
- simplify profile editing to only cover contact details while keeping success messaging intact

## Testing
- php -l includes/navbar.php
- php -l profile.php
- php -l change_password.php

------
https://chatgpt.com/codex/tasks/task_e_68d34fcbb1b8833180c11285fac6f0bd