### PR TITLE
Split participant management into dedicated pages

### DIFF
--- a/participant_form.php
+++ b/participant_form.php
@@ -1,0 +1,275 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+require_login();
+require_role(['institution_admin']);
+
+$user = current_user();
+$db = get_db_connection();
+$role = $user['role'];
+$can_manage = $role === 'institution_admin';
+
+if (!$can_manage) {
+    echo '<div class="alert alert-danger">Only institution administrators can manage participants.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+if (!$user['institution_id']) {
+    echo '<div class="alert alert-warning">No institution assigned to your account. Please contact the event administrator.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$institution_id = (int) $user['institution_id'];
+$stmt = $db->prepare('SELECT id, name, event_id FROM institutions WHERE id = ?');
+$stmt->bind_param('i', $institution_id);
+$stmt->execute();
+$institution_context = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if (!$institution_context) {
+    echo '<div class="alert alert-danger">Unable to load institution information.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+$event_id = (int) $institution_context['event_id'];
+
+$participant_id = (int) get_param('id', 0);
+$is_edit = $participant_id > 0;
+$existing_participant = null;
+
+if ($is_edit) {
+    $stmt = $db->prepare('SELECT * FROM participants WHERE id = ? AND institution_id = ?');
+    $stmt->bind_param('ii', $participant_id, $institution_id);
+    $stmt->execute();
+    $existing_participant = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if (!$existing_participant) {
+        echo '<div class="alert alert-danger">Participant not found.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+    if ($existing_participant['status'] === 'submitted') {
+        echo '<div class="alert alert-warning">Submitted participants cannot be edited.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+}
+
+$errors = [];
+$data = [
+    'name' => '',
+    'date_of_birth' => '',
+    'gender' => '',
+    'guardian_name' => '',
+    'contact_number' => '',
+    'address' => '',
+    'email' => '',
+    'aadhaar_number' => '',
+    'photo_path' => $existing_participant['photo_path'] ?? null,
+];
+
+if ($existing_participant) {
+    $data = array_merge($data, [
+        'name' => $existing_participant['name'] ?? '',
+        'date_of_birth' => $existing_participant['date_of_birth'] ?? '',
+        'gender' => $existing_participant['gender'] ?? '',
+        'guardian_name' => $existing_participant['guardian_name'] ?? '',
+        'contact_number' => $existing_participant['contact_number'] ?? '',
+        'address' => $existing_participant['address'] ?? '',
+        'email' => $existing_participant['email'] ?? '',
+        'aadhaar_number' => $existing_participant['aadhaar_number'] ?? '',
+    ]);
+}
+
+function process_participant_photo(?array $file, ?string $currentPath, array &$errors): ?string
+{
+    if (!$file || ($file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE) {
+        return $currentPath;
+    }
+
+    if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+        $errors['photo'] = 'Failed to upload passport photo.';
+        return null;
+    }
+
+    if (($file['size'] ?? 0) > 2 * 1024 * 1024) {
+        $errors['photo'] = 'Passport photo must be smaller than 2MB.';
+        return null;
+    }
+
+    $info = @getimagesize($file['tmp_name']);
+    if (!$info || !in_array($info[2], [IMAGETYPE_JPEG, IMAGETYPE_PNG], true)) {
+        $errors['photo'] = 'Passport photo must be a JPG or PNG image.';
+        return null;
+    }
+
+    $extension = $info[2] === IMAGETYPE_PNG ? 'png' : 'jpg';
+    $uploadDir = __DIR__ . '/uploads/participants';
+    if (!is_dir($uploadDir) && !mkdir($uploadDir, 0777, true) && !is_dir($uploadDir)) {
+        $errors['photo'] = 'Unable to prepare the upload directory.';
+        return null;
+    }
+
+    try {
+        $random = bin2hex(random_bytes(4));
+    } catch (Throwable $e) {
+        $random = uniqid('', true);
+    }
+
+    $filename = 'participant_' . time() . '_' . preg_replace('/[^a-zA-Z0-9_\-\.]/', '', $random) . '.' . $extension;
+    $destination = $uploadDir . '/' . $filename;
+
+    if (!move_uploaded_file($file['tmp_name'], $destination)) {
+        $errors['photo'] = 'Failed to save the uploaded passport photo.';
+        return null;
+    }
+
+    if ($currentPath) {
+        $existing = __DIR__ . '/' . ltrim($currentPath, '/');
+        if (is_file($existing)) {
+            @unlink($existing);
+        }
+    }
+
+    return 'uploads/participants/' . $filename;
+}
+
+if (is_post()) {
+    $data = [
+        'name' => trim((string) post_param('name', '')),
+        'date_of_birth' => post_param('date_of_birth'),
+        'gender' => post_param('gender'),
+        'guardian_name' => trim((string) post_param('guardian_name', '')),
+        'contact_number' => trim((string) post_param('contact_number', '')),
+        'address' => trim((string) post_param('address', '')),
+        'email' => trim((string) post_param('email', '')),
+        'aadhaar_number' => trim((string) post_param('aadhaar_number', '')),
+        'photo_path' => $existing_participant['photo_path'] ?? null,
+    ];
+
+    $data['aadhaar_number'] = preg_replace('/\D+/', '', $data['aadhaar_number']);
+    $photo_file = $_FILES['photo'] ?? null;
+
+    if (!$is_edit && (!$photo_file || ($photo_file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE)) {
+        $errors['photo'] = 'Passport photo is required.';
+    }
+
+    validate_required([
+        'name' => 'Participant name',
+        'date_of_birth' => 'Date of birth',
+        'gender' => 'Gender',
+        'guardian_name' => "Guardian's name",
+        'contact_number' => 'Contact number',
+        'aadhaar_number' => 'Aadhaar number',
+    ], $errors, array_merge($data, ['date_of_birth' => $data['date_of_birth'] ?? '', 'gender' => $data['gender'] ?? '']));
+
+    if ($data['gender'] && !in_array($data['gender'], ['Male', 'Female'], true)) {
+        $errors['gender'] = 'Invalid gender selection.';
+    }
+
+    if ($data['aadhaar_number'] && !preg_match('/^\d{12}$/', $data['aadhaar_number'])) {
+        $errors['aadhaar_number'] = 'Aadhaar number must contain exactly 12 digits.';
+    }
+
+    if (!$errors) {
+        $photo_path = process_participant_photo($photo_file, $data['photo_path'], $errors);
+        if (!$errors) {
+            $data['photo_path'] = $photo_path;
+        }
+    }
+
+    if (!$errors) {
+        if ($is_edit) {
+            $stmt = $db->prepare('UPDATE participants SET name = ?, date_of_birth = ?, gender = ?, guardian_name = ?, contact_number = ?, address = ?, email = ?, aadhaar_number = ?, photo_path = ?, updated_at = NOW() WHERE id = ? AND institution_id = ?');
+            $stmt->bind_param('sssssssssii', $data['name'], $data['date_of_birth'], $data['gender'], $data['guardian_name'], $data['contact_number'], $data['address'], $data['email'], $data['aadhaar_number'], $data['photo_path'], $participant_id, $institution_id);
+            $stmt->execute();
+            $stmt->close();
+            set_flash('success', 'Participant updated successfully.');
+        } else {
+            $stmt = $db->prepare("INSERT INTO participants (institution_id, event_id, name, date_of_birth, gender, guardian_name, contact_number, address, email, aadhaar_number, photo_path, status, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'draft', ?)");
+            $created_by = $user['id'];
+            $stmt->bind_param('iisssssssssi', $institution_id, $event_id, $data['name'], $data['date_of_birth'], $data['gender'], $data['guardian_name'], $data['contact_number'], $data['address'], $data['email'], $data['aadhaar_number'], $data['photo_path'], $created_by);
+            $stmt->execute();
+            $stmt->close();
+            set_flash('success', 'Participant created successfully.');
+        }
+        redirect('participants.php');
+    }
+}
+
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0"><?php echo $is_edit ? 'Edit Participant' : 'Add Participant'; ?></h1>
+        <p class="text-muted mb-0"><?php echo $is_edit ? 'Update the participant details.' : 'Register a new participant for your institution.'; ?></p>
+    </div>
+    <a href="participants.php" class="btn btn-outline-secondary">Back to Participants</a>
+</div>
+<div class="card shadow-sm">
+    <div class="card-body">
+        <?php if (isset($errors['general'])): ?>
+            <div class="alert alert-danger"><?php echo sanitize($errors['general']); ?></div>
+        <?php endif; ?>
+        <form method="post" enctype="multipart/form-data" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label" for="name">Full Name</label>
+                <input type="text" class="form-control <?php echo isset($errors['name']) ? 'is-invalid' : ''; ?>" id="name" name="name" value="<?php echo sanitize($data['name']); ?>" required>
+                <?php if (isset($errors['name'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['name']); ?></div><?php endif; ?>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label" for="date_of_birth">Date of Birth</label>
+                <input type="date" class="form-control <?php echo isset($errors['date_of_birth']) ? 'is-invalid' : ''; ?>" id="date_of_birth" name="date_of_birth" value="<?php echo sanitize($data['date_of_birth']); ?>" required>
+                <?php if (isset($errors['date_of_birth'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['date_of_birth']); ?></div><?php endif; ?>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label" for="gender">Gender</label>
+                <select class="form-select <?php echo isset($errors['gender']) ? 'is-invalid' : ''; ?>" id="gender" name="gender" required>
+                    <option value="">Select Gender</option>
+                    <option value="Male" <?php echo $data['gender'] === 'Male' ? 'selected' : ''; ?>>Male</option>
+                    <option value="Female" <?php echo $data['gender'] === 'Female' ? 'selected' : ''; ?>>Female</option>
+                </select>
+                <?php if (isset($errors['gender'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['gender']); ?></div><?php endif; ?>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label" for="guardian_name">Guardian Name</label>
+                <input type="text" class="form-control <?php echo isset($errors['guardian_name']) ? 'is-invalid' : ''; ?>" id="guardian_name" name="guardian_name" value="<?php echo sanitize($data['guardian_name']); ?>" required>
+                <?php if (isset($errors['guardian_name'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['guardian_name']); ?></div><?php endif; ?>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label" for="contact_number">Contact Number</label>
+                <input type="text" class="form-control <?php echo isset($errors['contact_number']) ? 'is-invalid' : ''; ?>" id="contact_number" name="contact_number" value="<?php echo sanitize($data['contact_number']); ?>" required>
+                <?php if (isset($errors['contact_number'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['contact_number']); ?></div><?php endif; ?>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label" for="aadhaar_number">Aadhaar Number</label>
+                <input type="text" class="form-control <?php echo isset($errors['aadhaar_number']) ? 'is-invalid' : ''; ?>" id="aadhaar_number" name="aadhaar_number" value="<?php echo sanitize($data['aadhaar_number']); ?>" required>
+                <?php if (isset($errors['aadhaar_number'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['aadhaar_number']); ?></div><?php endif; ?>
+                <div class="form-text">Enter the 12-digit Aadhaar number for the participant.</div>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label" for="email">Email</label>
+                <input type="email" class="form-control" id="email" name="email" value="<?php echo sanitize($data['email']); ?>">
+            </div>
+            <div class="col-md-6">
+                <label class="form-label" for="photo">Passport Photo</label>
+                <?php if (!empty($data['photo_path'])): ?>
+                    <div class="mb-2">
+                        <img src="<?php echo sanitize($data['photo_path']); ?>" alt="Passport photo preview" class="img-thumbnail" style="max-width: 140px;">
+                    </div>
+                <?php endif; ?>
+                <input type="file" class="form-control <?php echo isset($errors['photo']) ? 'is-invalid' : ''; ?>" id="photo" name="photo" accept="image/png,image/jpeg" <?php echo $data['photo_path'] ? '' : 'required'; ?>>
+                <?php if (isset($errors['photo'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['photo']); ?></div><?php endif; ?>
+                <div class="form-text">Upload a JPG or PNG image up to 2MB.</div>
+            </div>
+            <div class="col-12">
+                <label class="form-label" for="address">Address</label>
+                <textarea class="form-control" id="address" name="address" rows="3"><?php echo sanitize($data['address']); ?></textarea>
+            </div>
+            <div class="col-12 d-flex justify-content-end gap-2 mt-3">
+                <a href="participants.php" class="btn btn-outline-secondary">Cancel</a>
+                <button class="btn btn-primary" type="submit"><?php echo $is_edit ? 'Update Participant' : 'Create Participant'; ?></button>
+            </div>
+        </form>
+    </div>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/participant_view.php
+++ b/participant_view.php
@@ -1,0 +1,225 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+require_login();
+require_role(['institution_admin', 'event_admin', 'event_staff', 'super_admin']);
+
+$user = current_user();
+$db = get_db_connection();
+$role = $user['role'];
+
+$event_id = null;
+$institution_id = null;
+$institution_context = null;
+
+if ($role === 'institution_admin') {
+    if (!$user['institution_id']) {
+        echo '<div class="alert alert-warning">No institution assigned to your account. Please contact the event administrator.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+    $institution_id = (int) $user['institution_id'];
+    $stmt = $db->prepare('SELECT id, name, event_id FROM institutions WHERE id = ?');
+    $stmt->bind_param('i', $institution_id);
+    $stmt->execute();
+    $institution_context = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if (!$institution_context) {
+        echo '<div class="alert alert-danger">Unable to load institution information.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+    $event_id = (int) $institution_context['event_id'];
+} elseif ($role === 'event_admin' || $role === 'event_staff') {
+    if (!$user['event_id']) {
+        echo '<div class="alert alert-warning">No event assigned to your account. Please contact the super administrator.</div>';
+        include __DIR__ . '/includes/footer.php';
+        return;
+    }
+    $event_id = (int) $user['event_id'];
+    $institution_id = (int) get_param('institution_id', 0) ?: null;
+} else {
+    $event_id = (int) get_param('event_id', 0) ?: null;
+    $institution_id = (int) get_param('institution_id', 0) ?: null;
+}
+
+$participant_id = (int) get_param('id', 0);
+if (!$participant_id) {
+    echo '<div class="alert alert-warning">Participant not specified.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+function load_participant_with_access(mysqli $db, int $participant_id, ?int $institution_id, ?int $event_id, string $role): ?array
+{
+    $sql = 'SELECT p.*, i.name AS institution_name FROM participants p LEFT JOIN institutions i ON i.id = p.institution_id WHERE p.id = ?';
+    $params = [$participant_id];
+    $types = 'i';
+
+    if ($role === 'institution_admin') {
+        $sql .= ' AND p.institution_id = ?';
+        $params[] = $institution_id;
+        $types .= 'i';
+    } elseif ($role === 'event_admin' || $role === 'event_staff') {
+        $sql .= ' AND p.event_id = ?';
+        $params[] = $event_id;
+        $types .= 'i';
+        if ($institution_id) {
+            $sql .= ' AND p.institution_id = ?';
+            $params[] = $institution_id;
+            $types .= 'i';
+        }
+    } elseif ($role === 'super_admin') {
+        if ($event_id) {
+            $sql .= ' AND p.event_id = ?';
+            $params[] = $event_id;
+            $types .= 'i';
+        }
+        if ($institution_id) {
+            $sql .= ' AND p.institution_id = ?';
+            $params[] = $institution_id;
+            $types .= 'i';
+        }
+    }
+
+    $stmt = $db->prepare($sql);
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $participant = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    return $participant ?: null;
+}
+
+$participant = load_participant_with_access($db, $participant_id, $institution_id, $event_id, $role);
+if (!$participant) {
+    echo '<div class="alert alert-danger">Unable to load participant details or insufficient permissions.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$stmt = $db->prepare('SELECT pe.id, em.name, em.code, em.label, em.event_type, em.fees, ac.name AS age_category_name FROM participant_events pe JOIN event_master em ON em.id = pe.event_master_id JOIN age_categories ac ON ac.id = em.age_category_id WHERE pe.participant_id = ? ORDER BY em.name');
+$stmt->bind_param('i', $participant_id);
+$stmt->execute();
+$assigned_events = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$total_events = count($assigned_events);
+$total_fees = 0.0;
+foreach ($assigned_events as $event) {
+    $total_fees += (float) $event['fees'];
+}
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0">Participant Details</h1>
+        <p class="text-muted mb-0">Review registration information and participation history.</p>
+    </div>
+    <a href="participants.php" class="btn btn-outline-secondary">Close</a>
+</div>
+<div class="card shadow-sm mb-4">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <div>
+            <h2 class="h6 mb-0"><?php echo sanitize($participant['name']); ?></h2>
+            <span class="badge bg-<?php echo $participant['status'] === 'submitted' ? 'success' : 'secondary'; ?> text-uppercase"><?php echo sanitize($participant['status']); ?></span>
+        </div>
+        <div class="text-end">
+            <div class="small text-muted">Total Events</div>
+            <div class="fw-semibold"><?php echo (int) $total_events; ?></div>
+            <div class="small text-muted mt-2">Total Fees</div>
+            <div class="fw-semibold">₹<?php echo number_format($total_fees, 2); ?></div>
+        </div>
+    </div>
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-md-4">
+                <div class="text-muted small">Full Name</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['name']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Date of Birth</div>
+                <div class="fw-semibold"><?php echo format_date($participant['date_of_birth']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Gender</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['gender']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Guardian</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['guardian_name']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Contact</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['contact_number']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Aadhaar Number</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['aadhaar_number']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Email</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['email']); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Passport Photo</div>
+                <?php if (!empty($participant['photo_path'])): ?>
+                    <div>
+                        <img src="<?php echo sanitize($participant['photo_path']); ?>" alt="Passport photo" class="img-thumbnail" style="max-width: 140px;">
+                    </div>
+                <?php else: ?>
+                    <div class="text-muted">No photo uploaded</div>
+                <?php endif; ?>
+            </div>
+            <div class="col-md-12">
+                <div class="text-muted small">Address</div>
+                <div class="fw-semibold"><?php echo nl2br(sanitize($participant['address'])); ?></div>
+            </div>
+            <div class="col-md-4">
+                <div class="text-muted small">Institution</div>
+                <div class="fw-semibold"><?php echo sanitize($participant['institution_name']); ?></div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="card shadow-sm">
+    <div class="card-body">
+        <h2 class="h6 mb-3">Participation Events</h2>
+        <div class="table-responsive">
+            <table class="table table-striped align-middle">
+                <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Event Name</th>
+                        <th>Label</th>
+                        <th>Age Category</th>
+                        <th>Type</th>
+                        <th class="text-end">Fees</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($assigned_events as $event): ?>
+                    <tr>
+                        <td class="fw-semibold"><?php echo sanitize($event['code']); ?></td>
+                        <td><?php echo sanitize($event['name']); ?></td>
+                        <td><?php echo $event['label'] ? sanitize($event['label']) : '<span class="text-muted">-</span>'; ?></td>
+                        <td><?php echo sanitize($event['age_category_name']); ?></td>
+                        <td><?php echo sanitize($event['event_type']); ?></td>
+                        <td class="text-end">₹<?php echo number_format((float) $event['fees'], 2); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                <?php if ($assigned_events): ?>
+                    <tr class="fw-semibold">
+                        <td colspan="4" class="text-end">Totals</td>
+                        <td class="text-end"><?php echo (int) $total_events; ?> events</td>
+                        <td class="text-end">₹<?php echo number_format($total_fees, 2); ?></td>
+                    </tr>
+                <?php else: ?>
+                    <tr>
+                        <td colspan="6" class="text-center text-muted py-4">No events assigned to this participant.</td>
+                    </tr>
+                <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/participants.php
+++ b/participants.php
@@ -45,9 +45,6 @@ if ($role === 'institution_admin') {
 
 $status_filter = get_param('status');
 $search = trim((string) get_param('q', ''));
-$errors = [];
-$edit_participant = null;
-$view_participant = null;
 
 function fetch_participant(mysqli $db, int $id, ?int $institution_id): ?array
 {
@@ -68,146 +65,9 @@ function fetch_participant(mysqli $db, int $id, ?int $institution_id): ?array
     return $participant ?: null;
 }
 
-function process_participant_photo(?array $file, ?string $currentPath, array &$errors): ?string
-{
-    if (!$file || ($file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE) {
-        return $currentPath;
-    }
-
-    if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
-        $errors['photo'] = 'Failed to upload passport photo.';
-        return null;
-    }
-
-    if (($file['size'] ?? 0) > 2 * 1024 * 1024) {
-        $errors['photo'] = 'Passport photo must be smaller than 2MB.';
-        return null;
-    }
-
-    $info = @getimagesize($file['tmp_name']);
-    if (!$info || !in_array($info[2], [IMAGETYPE_JPEG, IMAGETYPE_PNG], true)) {
-        $errors['photo'] = 'Passport photo must be a JPG or PNG image.';
-        return null;
-    }
-
-    $extension = $info[2] === IMAGETYPE_PNG ? 'png' : 'jpg';
-    $uploadDir = __DIR__ . '/uploads/participants';
-    if (!is_dir($uploadDir) && !mkdir($uploadDir, 0777, true) && !is_dir($uploadDir)) {
-        $errors['photo'] = 'Unable to prepare the upload directory.';
-        return null;
-    }
-
-    try {
-        $random = bin2hex(random_bytes(4));
-    } catch (Throwable $e) {
-        $random = uniqid('', true);
-    }
-
-    $filename = 'participant_' . time() . '_' . preg_replace('/[^a-zA-Z0-9_\-\.]/', '', $random) . '.' . $extension;
-    $destination = $uploadDir . '/' . $filename;
-
-    if (!move_uploaded_file($file['tmp_name'], $destination)) {
-        $errors['photo'] = 'Failed to save the uploaded passport photo.';
-        return null;
-    }
-
-    if ($currentPath) {
-        $existing = __DIR__ . '/' . ltrim($currentPath, '/');
-        if (is_file($existing)) {
-            @unlink($existing);
-        }
-    }
-
-    return 'uploads/participants/' . $filename;
-}
-
 if (is_post() && $can_manage) {
     $action = post_param('action');
-    if (in_array($action, ['create', 'update'], true)) {
-        $data = [
-            'name' => trim((string) post_param('name', '')),
-            'date_of_birth' => post_param('date_of_birth'),
-            'gender' => post_param('gender'),
-            'guardian_name' => trim((string) post_param('guardian_name', '')),
-            'contact_number' => trim((string) post_param('contact_number', '')),
-            'address' => trim((string) post_param('address', '')),
-            'email' => trim((string) post_param('email', '')),
-            'aadhaar_number' => trim((string) post_param('aadhaar_number', '')),
-        ];
-
-        $data['aadhaar_number'] = preg_replace('/\D+/', '', $data['aadhaar_number']);
-        $photo_file = $_FILES['photo'] ?? null;
-        $current_photo_path = null;
-        $participant = null;
-
-        if ($action === 'update') {
-            $participant_id = (int) post_param('id');
-            $participant = fetch_participant($db, $participant_id, $institution_id);
-            if (!$participant) {
-                $errors['general'] = 'Participant not found.';
-            } elseif ($participant['status'] === 'submitted') {
-                $errors['general'] = 'Submitted participants cannot be edited.';
-            } else {
-                $current_photo_path = $participant['photo_path'] ?? null;
-            }
-        }
-
-        if ($action === 'create' && (!$photo_file || ($photo_file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE)) {
-            $errors['photo'] = 'Passport photo is required.';
-        }
-
-        validate_required([
-            'name' => 'Participant name',
-            'date_of_birth' => 'Date of birth',
-            'gender' => 'Gender',
-            'guardian_name' => "Guardian's name",
-            'contact_number' => 'Contact number',
-            'aadhaar_number' => 'Aadhaar number',
-        ], $errors, array_merge($data, ['date_of_birth' => $data['date_of_birth'] ?? '', 'gender' => $data['gender'] ?? '']));
-
-        if ($data['gender'] && !in_array($data['gender'], ['Male', 'Female'], true)) {
-            $errors['gender'] = 'Invalid gender selection.';
-        }
-
-        if ($data['aadhaar_number'] && !preg_match('/^\d{12}$/', $data['aadhaar_number'])) {
-            $errors['aadhaar_number'] = 'Aadhaar number must contain exactly 12 digits.';
-        }
-
-        if (!$errors) {
-            $photo_path = process_participant_photo($photo_file, $current_photo_path, $errors);
-            if (!$errors) {
-                $data['photo_path'] = $photo_path;
-            }
-        }
-
-        if (!$errors) {
-            if ($action === 'create') {
-                $stmt = $db->prepare('INSERT INTO participants (institution_id, event_id, name, date_of_birth, gender, guardian_name, contact_number, address, email, aadhaar_number, photo_path, status, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \'draft\', ?)');
-                $created_by = $user['id'];
-                $stmt->bind_param('iisssssssssi', $institution_id, $event_id, $data['name'], $data['date_of_birth'], $data['gender'], $data['guardian_name'], $data['contact_number'], $data['address'], $data['email'], $data['aadhaar_number'], $data['photo_path'], $created_by);
-                $stmt->execute();
-                $stmt->close();
-                set_flash('success', 'Participant created successfully.');
-            } else {
-                $participant_id = (int) post_param('id');
-                $stmt = $db->prepare('UPDATE participants SET name = ?, date_of_birth = ?, gender = ?, guardian_name = ?, contact_number = ?, address = ?, email = ?, aadhaar_number = ?, photo_path = ?, updated_at = NOW() WHERE id = ?');
-                $stmt->bind_param('sssssssssi', $data['name'], $data['date_of_birth'], $data['gender'], $data['guardian_name'], $data['contact_number'], $data['address'], $data['email'], $data['aadhaar_number'], $data['photo_path'], $participant_id);
-                $stmt->execute();
-                $stmt->close();
-                set_flash('success', 'Participant updated successfully.');
-                redirect('participants.php');
-            }
-            if (!$errors) {
-                redirect('participants.php');
-            }
-        }
-
-        $edit_participant = $data;
-        $edit_participant['id'] = (int) post_param('id');
-        if (!isset($edit_participant['photo_path'])) {
-            $edit_participant['photo_path'] = $current_photo_path;
-        }
-    } elseif ($action === 'delete') {
+    if ($action === 'delete') {
         $participant_id = (int) post_param('id');
         $participant = fetch_participant($db, $participant_id, $institution_id);
         if ($participant && $participant['status'] !== 'submitted') {
@@ -230,7 +90,7 @@ if (is_post() && $can_manage) {
         $participant_id = (int) post_param('id');
         $participant = fetch_participant($db, $participant_id, $institution_id);
         if ($participant && $participant['status'] === 'draft') {
-            $stmt = $db->prepare('UPDATE participants SET status = \'submitted\', submitted_at = NOW(), submitted_by = ? WHERE id = ?');
+            $stmt = $db->prepare("UPDATE participants SET status = 'submitted', submitted_at = NOW(), submitted_by = ? WHERE id = ?");
             $stmt->bind_param('ii', $user['id'], $participant_id);
             $stmt->execute();
             $stmt->close();
@@ -242,49 +102,12 @@ if (is_post() && $can_manage) {
     }
 }
 
-if (!$edit_participant && ($edit_id = (int) get_param('edit', 0)) && $can_manage) {
-    $participant = fetch_participant($db, $edit_id, $institution_id);
-    if ($participant) {
-        $edit_participant = $participant;
-    }
-}
-
-$view_id = (int) get_param('view', 0);
-if ($view_id) {
-    $sql = "SELECT p.*, i.name AS institution_name FROM participants p LEFT JOIN institutions i ON i.id = p.institution_id WHERE p.id = ?";
-    $types = 'i';
-    $params = [$view_id];
-    if ($role === 'institution_admin') {
-        $sql .= ' AND p.institution_id = ?';
-        $types .= 'i';
-        $params[] = $institution_id;
-    } elseif ($role === 'event_admin' || $role === 'event_staff') {
-        $sql .= ' AND p.event_id = ?';
-        $types .= 'i';
-        $params[] = $event_id;
-    } elseif ($role === 'super_admin') {
-        if ($event_id) {
-            $sql .= ' AND p.event_id = ?';
-            $types .= 'i';
-            $params[] = $event_id;
-        }
-        if ($institution_id) {
-            $sql .= ' AND p.institution_id = ?';
-            $types .= 'i';
-            $params[] = $institution_id;
-        }
-    }
-    $stmt = $db->prepare($sql);
-    $stmt->bind_param($types, ...$params);
-    $stmt->execute();
-    $view_participant = $stmt->get_result()->fetch_assoc();
-    $stmt->close();
-}
-
-$sql = "SELECT p.*, i.name AS institution_name\n        FROM participants p\n        LEFT JOIN institutions i ON i.id = p.institution_id";
+$statsSubquery = 'SELECT participant_id, COUNT(*) AS total_events, COALESCE(SUM(fees), 0) AS total_fees FROM participant_events GROUP BY participant_id';
+$sql = "SELECT p.id, p.institution_id, p.event_id, p.name, p.email, p.date_of_birth, p.gender, p.guardian_name, p.contact_number, p.status, i.name AS institution_name, COALESCE(stats.total_events, 0) AS total_events, COALESCE(stats.total_fees, 0) AS total_fees FROM participants p LEFT JOIN institutions i ON i.id = p.institution_id LEFT JOIN ($statsSubquery) stats ON stats.participant_id = p.id";
 $conditions = [];
 $params = [];
 $types = '';
+
 if ($event_id) {
     $conditions[] = 'p.event_id = ?';
     $params[] = $event_id;
@@ -321,15 +144,25 @@ $stmt->execute();
 $participants = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
 $stmt->close();
 
+$total_events_sum = 0;
+$total_fees_sum = 0.0;
+foreach ($participants as $participant) {
+    $total_events_sum += (int) $participant['total_events'];
+    $total_fees_sum += (float) $participant['total_fees'];
+}
+
 $flash_success = get_flash('success');
 $flash_error = get_flash('error');
 ?>
-<div class="d-flex justify-content-between align-items-center mb-4">
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
     <div>
         <h1 class="h4 mb-0">Participants</h1>
         <p class="text-muted mb-0">Manage participant registrations for the event.</p>
     </div>
-    <div class="d-flex gap-2">
+    <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
+        <?php if ($can_manage): ?>
+            <a href="participant_form.php" class="btn btn-primary">Add Participant</a>
+        <?php endif; ?>
         <form method="get" class="d-flex gap-2">
             <?php if ($role === 'event_admin' || $role === 'event_staff' || $role === 'super_admin'): ?>
                 <?php if ($role !== 'institution_admin'): ?>
@@ -357,211 +190,78 @@ $flash_error = get_flash('error');
 <?php if ($flash_error): ?>
     <div class="alert alert-danger"><?php echo sanitize($flash_error); ?></div>
 <?php endif; ?>
-<?php if ($view_participant): ?>
-    <div class="card shadow-sm mb-4">
-        <div class="card-header bg-white d-flex justify-content-between align-items-center">
-            <div>
-                <h2 class="h6 mb-0">Participant Details</h2>
-                <span class="badge bg-<?php echo $view_participant['status'] === 'submitted' ? 'success' : 'secondary'; ?> text-uppercase"><?php echo sanitize($view_participant['status']); ?></span>
-            </div>
-            <a href="participants.php" class="btn btn-sm btn-outline-secondary">Close</a>
-        </div>
-        <div class="card-body">
-            <div class="row g-3">
-                <div class="col-md-4">
-                    <div class="text-muted small">Full Name</div>
-                    <div class="fw-semibold"><?php echo sanitize($view_participant['name']); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Date of Birth</div>
-                    <div class="fw-semibold"><?php echo format_date($view_participant['date_of_birth']); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Gender</div>
-                    <div class="fw-semibold"><?php echo sanitize($view_participant['gender']); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Guardian</div>
-                    <div class="fw-semibold"><?php echo sanitize($view_participant['guardian_name']); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Contact</div>
-                    <div class="fw-semibold"><?php echo sanitize($view_participant['contact_number']); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Aadhaar Number</div>
-                    <div class="fw-semibold"><?php echo sanitize($view_participant['aadhaar_number']); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Email</div>
-                    <div class="fw-semibold"><?php echo sanitize($view_participant['email']); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Passport Photo</div>
-                    <?php if (!empty($view_participant['photo_path'])): ?>
-                        <div>
-                            <img src="<?php echo sanitize($view_participant['photo_path']); ?>" alt="Passport photo" class="img-thumbnail" style="max-width: 140px;">
-                        </div>
-                    <?php else: ?>
-                        <div class="text-muted">No photo uploaded</div>
-                    <?php endif; ?>
-                </div>
-                <div class="col-md-12">
-                    <div class="text-muted small">Address</div>
-                    <div class="fw-semibold"><?php echo nl2br(sanitize($view_participant['address'])); ?></div>
-                </div>
-                <div class="col-md-4">
-                    <div class="text-muted small">Institution</div>
-                    <div class="fw-semibold"><?php echo sanitize($view_participant['institution_name']); ?></div>
-                </div>
-            </div>
-        </div>
-    </div>
-<?php endif; ?>
-<div class="row g-4">
-    <?php if ($can_manage): ?>
-    <div class="col-lg-4">
-        <div class="card shadow-sm">
-            <div class="card-header bg-white">
-                <h2 class="h6 mb-0"><?php echo $edit_participant ? 'Edit Participant' : 'Add Participant'; ?></h2>
-            </div>
-            <div class="card-body">
-                <?php if (isset($errors['general'])): ?>
-                    <div class="alert alert-danger"><?php echo sanitize($errors['general']); ?></div>
-                <?php endif; ?>
-                <form method="post" enctype="multipart/form-data">
-                    <input type="hidden" name="action" value="<?php echo $edit_participant ? 'update' : 'create'; ?>">
-                    <input type="hidden" name="id" value="<?php echo (int) ($edit_participant['id'] ?? 0); ?>">
-                    <div class="mb-3">
-                        <label class="form-label" for="name">Full Name</label>
-                        <input type="text" class="form-control <?php echo isset($errors['name']) ? 'is-invalid' : ''; ?>" id="name" name="name" value="<?php echo sanitize($edit_participant['name'] ?? ''); ?>" required>
-                        <?php if (isset($errors['name'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['name']); ?></div><?php endif; ?>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="date_of_birth">Date of Birth</label>
-                        <input type="date" class="form-control <?php echo isset($errors['date_of_birth']) ? 'is-invalid' : ''; ?>" id="date_of_birth" name="date_of_birth" value="<?php echo sanitize($edit_participant['date_of_birth'] ?? ''); ?>" required>
-                        <?php if (isset($errors['date_of_birth'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['date_of_birth']); ?></div><?php endif; ?>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="gender">Gender</label>
-                        <select class="form-select <?php echo isset($errors['gender']) ? 'is-invalid' : ''; ?>" id="gender" name="gender" required>
-                            <option value="">Select Gender</option>
-                            <option value="Male" <?php echo (($edit_participant['gender'] ?? '') === 'Male') ? 'selected' : ''; ?>>Male</option>
-                            <option value="Female" <?php echo (($edit_participant['gender'] ?? '') === 'Female') ? 'selected' : ''; ?>>Female</option>
-                        </select>
-                        <?php if (isset($errors['gender'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['gender']); ?></div><?php endif; ?>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="guardian_name">Guardian Name</label>
-                        <input type="text" class="form-control <?php echo isset($errors['guardian_name']) ? 'is-invalid' : ''; ?>" id="guardian_name" name="guardian_name" value="<?php echo sanitize($edit_participant['guardian_name'] ?? ''); ?>" required>
-                        <?php if (isset($errors['guardian_name'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['guardian_name']); ?></div><?php endif; ?>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="contact_number">Contact Number</label>
-                        <input type="text" class="form-control <?php echo isset($errors['contact_number']) ? 'is-invalid' : ''; ?>" id="contact_number" name="contact_number" value="<?php echo sanitize($edit_participant['contact_number'] ?? ''); ?>" required>
-                        <?php if (isset($errors['contact_number'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['contact_number']); ?></div><?php endif; ?>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="aadhaar_number">Aadhaar Number</label>
-                        <input type="text" class="form-control <?php echo isset($errors['aadhaar_number']) ? 'is-invalid' : ''; ?>" id="aadhaar_number" name="aadhaar_number" value="<?php echo sanitize($edit_participant['aadhaar_number'] ?? ''); ?>" required>
-                        <?php if (isset($errors['aadhaar_number'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['aadhaar_number']); ?></div><?php endif; ?>
-                        <div class="form-text">Enter the 12-digit Aadhaar number for the participant.</div>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="email">Email</label>
-                        <input type="email" class="form-control" id="email" name="email" value="<?php echo sanitize($edit_participant['email'] ?? ''); ?>">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="photo">Passport Photo</label>
-                        <?php if (!empty($edit_participant['photo_path'])): ?>
-                            <div class="mb-2">
-                                <img src="<?php echo sanitize($edit_participant['photo_path']); ?>" alt="Passport photo preview" class="img-thumbnail" style="max-width: 120px;">
+<div class="card shadow-sm">
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-striped align-middle">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>DOB</th>
+                        <th>Gender</th>
+                        <th>Guardian</th>
+                        <th>Contact</th>
+                        <th class="text-center">Total Events</th>
+                        <th class="text-end">Total Fees</th>
+                        <th>Status</th>
+                        <?php if ($role !== 'institution_admin'): ?><th>Institution</th><?php endif; ?>
+                        <th class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($participants as $participant): ?>
+                    <tr>
+                        <td>
+                            <div class="fw-semibold"><?php echo sanitize($participant['name']); ?></div>
+                            <div class="text-muted small"><?php echo sanitize($participant['email']); ?></div>
+                        </td>
+                        <td><?php echo format_date($participant['date_of_birth']); ?></td>
+                        <td><?php echo sanitize($participant['gender']); ?></td>
+                        <td><?php echo sanitize($participant['guardian_name']); ?></td>
+                        <td><?php echo sanitize($participant['contact_number']); ?></td>
+                        <td class="text-center"><?php echo (int) $participant['total_events']; ?></td>
+                        <td class="text-end">₹<?php echo number_format((float) $participant['total_fees'], 2); ?></td>
+                        <td>
+                            <span class="badge bg-<?php echo $participant['status'] === 'submitted' ? 'success' : 'secondary'; ?> text-uppercase"><?php echo sanitize($participant['status']); ?></span>
+                        </td>
+                        <?php if ($role !== 'institution_admin'): ?><td><?php echo sanitize($participant['institution_name']); ?></td><?php endif; ?>
+                        <td class="text-end">
+                            <div class="table-actions justify-content-end flex-wrap gap-1">
+                                <a href="participant_events.php?participant_id=<?php echo (int) $participant['id']; ?>" class="btn btn-sm btn-outline-secondary" title="Manage Events">
+                                    <i class="bi bi-calendar-event"></i>
+                                </a>
+                                <a href="participant_view.php?id=<?php echo (int) $participant['id']; ?>" class="btn btn-sm btn-outline-secondary">View</a>
+                                <?php if ($can_manage && $participant['status'] === 'draft'): ?>
+                                    <a href="participant_form.php?id=<?php echo (int) $participant['id']; ?>" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil"></i></a>
+                                    <form method="post" onsubmit="return confirm('Delete this participant?');">
+                                        <input type="hidden" name="action" value="delete">
+                                        <input type="hidden" name="id" value="<?php echo (int) $participant['id']; ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                                    </form>
+                                    <form method="post" onsubmit="return confirm('Submit this participant? After submission edits are locked.');">
+                                        <input type="hidden" name="action" value="submit">
+                                        <input type="hidden" name="id" value="<?php echo (int) $participant['id']; ?>">
+                                        <button type="submit" class="btn btn-sm btn-outline-success"><i class="bi bi-send"></i></button>
+                                    </form>
+                                <?php endif; ?>
                             </div>
-                        <?php endif; ?>
-                        <input type="file" class="form-control <?php echo isset($errors['photo']) ? 'is-invalid' : ''; ?>" id="photo" name="photo" accept="image/png,image/jpeg" <?php echo !empty($edit_participant['photo_path']) ? '' : 'required'; ?>>
-                        <?php if (isset($errors['photo'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['photo']); ?></div><?php endif; ?>
-                        <div class="form-text">Upload a JPG or PNG image up to 2MB.</div>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label" for="address">Address</label>
-                        <textarea class="form-control" id="address" name="address" rows="3"><?php echo sanitize($edit_participant['address'] ?? ''); ?></textarea>
-                    </div>
-                    <div class="d-grid gap-2">
-                        <button class="btn btn-primary" type="submit"><?php echo $edit_participant ? 'Update Participant' : 'Create Participant'; ?></button>
-                        <?php if ($edit_participant): ?>
-                            <a href="participants.php" class="btn btn-outline-secondary">Cancel</a>
-                        <?php endif; ?>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-    <?php endif; ?>
-    <div class="col-lg-<?php echo $can_manage ? '8' : '12'; ?>">
-        <div class="card shadow-sm">
-            <div class="card-body">
-                <div class="table-responsive">
-                    <table class="table table-striped align-middle">
-                        <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>DOB</th>
-                                <th>Gender</th>
-                                <th>Guardian</th>
-                                <th>Contact</th>
-                                <th>Status</th>
-                                <?php if ($role !== 'institution_admin'): ?><th>Institution</th><?php endif; ?>
-                                <th class="text-end">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        <?php foreach ($participants as $participant): ?>
-                            <tr>
-                                <td>
-                                    <div class="fw-semibold"><?php echo sanitize($participant['name']); ?></div>
-                                    <div class="text-muted small"><?php echo sanitize($participant['email']); ?></div>
-                                </td>
-                                <td><?php echo format_date($participant['date_of_birth']); ?></td>
-                                <td><?php echo sanitize($participant['gender']); ?></td>
-                                <td><?php echo sanitize($participant['guardian_name']); ?></td>
-                                <td><?php echo sanitize($participant['contact_number']); ?></td>
-                                <td>
-                                    <span class="badge bg-<?php echo $participant['status'] === 'submitted' ? 'success' : 'secondary'; ?> text-uppercase"><?php echo sanitize($participant['status']); ?></span>
-                                </td>
-                                <?php if ($role !== 'institution_admin'): ?><td><?php echo sanitize($participant['institution_name']); ?></td><?php endif; ?>
-                                <td class="text-end">
-                                    <div class="table-actions justify-content-end">
-                                        <a href="participant_events.php?participant_id=<?php echo (int) $participant['id']; ?>" class="btn btn-sm btn-outline-secondary" title="Manage Events">
-                                            <i class="bi bi-calendar-event"></i>
-                                        </a>
-                                        <?php if ($can_manage && $participant['status'] === 'draft'): ?>
-                                            <a href="participants.php?edit=<?php echo (int) $participant['id']; ?>" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil"></i></a>
-                                            <form method="post" onsubmit="return confirm('Delete this participant?');">
-                                                <input type="hidden" name="action" value="delete">
-                                                <input type="hidden" name="id" value="<?php echo (int) $participant['id']; ?>">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
-                                            </form>
-                                            <form method="post" onsubmit="return confirm('Submit this participant? After submission edits are locked.');">
-                                                <input type="hidden" name="action" value="submit">
-                                                <input type="hidden" name="id" value="<?php echo (int) $participant['id']; ?>">
-                                                <button type="submit" class="btn btn-sm btn-outline-success"><i class="bi bi-send"></i></button>
-                                            </form>
-                                        <?php else: ?>
-                                            <a href="participants.php?view=<?php echo (int) $participant['id']; ?>" class="btn btn-sm btn-outline-secondary">View</a>
-                                        <?php endif; ?>
-                                    </div>
-                                </td>
-                            </tr>
-                        <?php endforeach; ?>
-                        <?php if (!$participants): ?>
-                            <tr>
-                                <td colspan="<?php echo $role !== 'institution_admin' ? '8' : '7'; ?>" class="text-center text-muted py-4">No participants found.</td>
-                            </tr>
-                        <?php endif; ?>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                <?php if ($participants): ?>
+                    <tr class="fw-semibold">
+                        <td colspan="5" class="text-end">Total</td>
+                        <td class="text-center"><?php echo (int) $total_events_sum; ?></td>
+                        <td class="text-end">₹<?php echo number_format($total_fees_sum, 2); ?></td>
+                        <td colspan="<?php echo $role !== 'institution_admin' ? '3' : '2'; ?>"></td>
+                    </tr>
+                <?php else: ?>
+                    <tr>
+                        <td colspan="<?php echo $role !== 'institution_admin' ? '10' : '9'; ?>" class="text-center text-muted py-4">No participants found.</td>
+                    </tr>
+                <?php endif; ?>
+                </tbody>
+            </table>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- refactor the participants listing to remove the inline form, add event/fee aggregates, and keep delete/submit actions
- add a dedicated participant form page for creating and editing entries with the existing validation and photo handling
- introduce a standalone participant detail view that shows registration info alongside assigned events and fee totals

## Testing
- php -l participants.php
- php -l participant_form.php
- php -l participant_view.php

------
https://chatgpt.com/codex/tasks/task_e_68d571009978833194913e4375b603b4