### PR TITLE
Display chest numbers and age categories in participant views

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -73,3 +73,52 @@ function get_flash(string $key): ?string
 
     return $message;
 }
+
+function calculate_age(?string $date_of_birth): ?int
+{
+    if (!$date_of_birth) {
+        return null;
+    }
+
+    try {
+        $dob = new DateTime($date_of_birth);
+        $today = new DateTime('today');
+    } catch (Exception $e) {
+        return null;
+    }
+
+    $diff = $dob->diff($today);
+
+    return $diff ? (int) $diff->y : null;
+}
+
+function fetch_age_categories(mysqli $db): array
+{
+    $result = $db->query('SELECT name, min_age, max_age FROM age_categories ORDER BY COALESCE(min_age, 0), COALESCE(max_age, 9999), name');
+    if (!$result) {
+        return [];
+    }
+
+    $categories = $result->fetch_all(MYSQLI_ASSOC);
+    $result->free();
+
+    return $categories;
+}
+
+function determine_age_category_label(?int $age, array $categories): ?string
+{
+    if ($age === null) {
+        return null;
+    }
+
+    foreach ($categories as $category) {
+        $min = array_key_exists('min_age', $category) && $category['min_age'] !== null ? (int) $category['min_age'] : null;
+        $max = array_key_exists('max_age', $category) && $category['max_age'] !== null ? (int) $category['max_age'] : null;
+
+        if (($min === null || $age >= $min) && ($max === null || $age <= $max)) {
+            return (string) $category['name'];
+        }
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Summary
- add shared helpers to compute participant ages and resolve age categories
- show chest numbers and derived age-category information on the participant details view
- update the participants list with serial numbers, chest numbers, and age category details beneath the DOB column

## Testing
- php -l includes/functions.php
- php -l participants.php
- php -l participant_view.php

------
https://chatgpt.com/codex/tasks/task_e_68d57adbafb4833196037dba2e1701a5