### PR TITLE
Add fund transfer workflow for institutions and event staff

### DIFF
--- a/event_staff_fund_transfer_view.php
+++ b/event_staff_fund_transfer_view.php
@@ -1,0 +1,243 @@
+<?php
+$page_title = 'Fund Transfer Details';
+require_once __DIR__ . '/includes/header.php';
+
+require_login();
+require_role(['event_staff']);
+
+$user = current_user();
+$db = get_db_connection();
+
+if (!$user['event_id']) {
+    echo '<div class="alert alert-warning">No event assigned to your account. Please contact the event administrator.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$event_id = (int) $user['event_id'];
+$transfer_id = (int) get_param('transfer_id', 0);
+
+if ($transfer_id <= 0) {
+    echo '<div class="alert alert-danger">Invalid transfer reference provided.</div>';
+    echo '<a href="event_staff_fund_transfers.php" class="btn btn-outline-secondary mt-3">Back to Fund Transfers</a>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+function fetch_transfer(mysqli $db, int $transfer_id, int $event_id): ?array
+{
+    $sql = "SELECT ft.*, i.name AS institution_name, i.contact_number AS institution_contact,
+                   submitter.name AS submitted_by_name, submitter.email AS submitted_by_email,
+                   reviewer.name AS reviewed_by_name
+            FROM fund_transfers ft
+            INNER JOIN institutions i ON i.id = ft.institution_id
+            LEFT JOIN users submitter ON submitter.id = ft.submitted_by
+            LEFT JOIN users reviewer ON reviewer.id = ft.reviewed_by
+            WHERE ft.id = ? AND ft.event_id = ?
+            LIMIT 1";
+
+    $stmt = $db->prepare($sql);
+    $stmt->bind_param('ii', $transfer_id, $event_id);
+    $stmt->execute();
+    $transfer = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    return $transfer ?: null;
+}
+
+if (is_post()) {
+    $action = (string) post_param('action', '');
+    $remarks = trim((string) post_param('remarks', ''));
+
+    if (!in_array($action, ['approve', 'reject'], true)) {
+        set_flash('error', 'Invalid action requested.');
+        redirect('event_staff_fund_transfer_view.php?transfer_id=' . $transfer_id);
+    }
+
+    if ($action === 'reject' && $remarks === '') {
+        set_flash('error', 'Please provide remarks when rejecting a fund transfer.');
+        redirect('event_staff_fund_transfer_view.php?transfer_id=' . $transfer_id);
+    }
+
+    $db->begin_transaction();
+
+    $stmt = $db->prepare('SELECT status FROM fund_transfers WHERE id = ? AND event_id = ? FOR UPDATE');
+    $stmt->bind_param('ii', $transfer_id, $event_id);
+    $stmt->execute();
+    $current = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    if (!$current) {
+        $db->rollback();
+        set_flash('error', 'Fund transfer not found or access denied.');
+        redirect('event_staff_fund_transfers.php');
+    }
+
+    $status = $current['status'];
+
+    if ($action === 'approve') {
+        if ($status === 'approved') {
+            $db->rollback();
+            set_flash('error', 'This fund transfer has already been approved.');
+            redirect('event_staff_fund_transfer_view.php?transfer_id=' . $transfer_id);
+        }
+
+        $stmt = $db->prepare('UPDATE fund_transfers SET status = "approved", reviewed_by = ?, reviewed_at = NOW(), remarks = ? WHERE id = ?');
+        $stmt->bind_param('isi', $user['id'], $remarks, $transfer_id);
+        $stmt->execute();
+        $stmt->close();
+
+        $db->commit();
+        set_flash('success', 'Fund transfer marked as approved.');
+        redirect('event_staff_fund_transfer_view.php?transfer_id=' . $transfer_id);
+    }
+
+    if ($action === 'reject') {
+        if ($status === 'rejected') {
+            $db->rollback();
+            set_flash('error', 'This fund transfer has already been rejected.');
+            redirect('event_staff_fund_transfer_view.php?transfer_id=' . $transfer_id);
+        }
+
+        $stmt = $db->prepare('UPDATE fund_transfers SET status = "rejected", reviewed_by = ?, reviewed_at = NOW(), remarks = ? WHERE id = ?');
+        $stmt->bind_param('isi', $user['id'], $remarks, $transfer_id);
+        $stmt->execute();
+        $stmt->close();
+
+        $db->commit();
+        set_flash('success', 'Fund transfer marked as rejected.');
+        redirect('event_staff_fund_transfer_view.php?transfer_id=' . $transfer_id);
+    }
+
+    $db->rollback();
+    set_flash('error', 'Unable to process the requested action.');
+    redirect('event_staff_fund_transfer_view.php?transfer_id=' . $transfer_id);
+}
+
+$transfer = fetch_transfer($db, $transfer_id, $event_id);
+
+if (!$transfer) {
+    echo '<div class="alert alert-danger">Fund transfer not found or access denied.</div>';
+    echo '<a href="event_staff_fund_transfers.php" class="btn btn-outline-secondary mt-3">Back to Fund Transfers</a>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$success_message = get_flash('success');
+$error_message = get_flash('error');
+
+$status_classes = [
+    'pending' => 'warning',
+    'approved' => 'success',
+    'rejected' => 'danger',
+];
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0">Fund Transfer Details</h1>
+        <p class="text-muted mb-0">Review submission from <?php echo sanitize($transfer['institution_name']); ?>.</p>
+    </div>
+    <div>
+        <a href="event_staff_fund_transfers.php" class="btn btn-outline-secondary">Back to Fund Transfers</a>
+    </div>
+</div>
+
+<?php if ($success_message): ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <?php echo sanitize($success_message); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+<?php endif; ?>
+
+<?php if ($error_message): ?>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <?php echo sanitize($error_message); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+<?php endif; ?>
+
+<div class="row g-4">
+    <div class="col-lg-7">
+        <div class="card shadow-sm h-100">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Submission Information</h2>
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Institution</dt>
+                    <dd class="col-sm-8"><?php echo sanitize($transfer['institution_name']); ?></dd>
+
+                    <dt class="col-sm-4">Submitted By</dt>
+                    <dd class="col-sm-8">
+                        <?php echo sanitize($transfer['submitted_by_name'] ?? 'Unknown'); ?><br>
+                        <span class="text-muted small"><?php echo sanitize($transfer['submitted_by_email'] ?? ''); ?></span>
+                    </dd>
+
+                    <dt class="col-sm-4">Transfer Date</dt>
+                    <dd class="col-sm-8"><?php echo sanitize(format_date($transfer['transfer_date'])); ?></dd>
+
+                    <dt class="col-sm-4">Mode</dt>
+                    <dd class="col-sm-8"><?php echo sanitize($transfer['mode']); ?></dd>
+
+                    <dt class="col-sm-4">Amount</dt>
+                    <dd class="col-sm-8">₹<?php echo number_format((float) $transfer['amount'], 2); ?></dd>
+
+                    <dt class="col-sm-4">Transaction Number</dt>
+                    <dd class="col-sm-8"><?php echo sanitize($transfer['transaction_number']); ?></dd>
+
+                    <dt class="col-sm-4">Status</dt>
+                    <dd class="col-sm-8">
+                        <span class="badge bg-<?php echo $status_classes[$transfer['status']] ?? 'secondary'; ?> text-uppercase">
+                            <?php echo sanitize($transfer['status']); ?>
+                        </span>
+                        <?php if ($transfer['reviewed_at']): ?>
+                            <div class="text-muted small mt-1">
+                                Reviewed on <?php echo sanitize(date('d M Y H:i', strtotime($transfer['reviewed_at']))); ?>
+                                <?php if ($transfer['reviewed_by_name']): ?>
+                                    <br>By <?php echo sanitize($transfer['reviewed_by_name']); ?>
+                                <?php endif; ?>
+                            </div>
+                        <?php endif; ?>
+                    </dd>
+
+                    <dt class="col-sm-4">Reference Document</dt>
+                    <dd class="col-sm-8">
+                        <a href="<?php echo sanitize($transfer['reference_document_path']); ?>" target="_blank" class="btn btn-sm btn-outline-secondary">View / Download</a>
+                    </dd>
+
+                    <?php if ($transfer['remarks']): ?>
+                        <dt class="col-sm-4">Remarks</dt>
+                        <dd class="col-sm-8"><?php echo nl2br(sanitize($transfer['remarks'])); ?></dd>
+                    <?php endif; ?>
+
+                    <dt class="col-sm-4">Submitted On</dt>
+                    <dd class="col-sm-8"><?php echo sanitize(date('d M Y H:i', strtotime($transfer['created_at']))); ?></dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-5">
+        <div class="card shadow-sm h-100">
+            <div class="card-body">
+                <h2 class="h5 mb-3">Review Actions</h2>
+                <?php if ($transfer['status'] === 'pending'): ?>
+                    <form method="post" class="mb-3">
+                        <div class="mb-3">
+                            <label for="remarks" class="form-label">Remarks (optional for approval)</label>
+                            <textarea name="remarks" id="remarks" class="form-control" rows="3" placeholder="Add remarks for the institution (required when rejecting)"></textarea>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <button type="submit" name="action" value="approve" class="btn btn-success">Approve</button>
+                            <button type="submit" name="action" value="reject" class="btn btn-danger">Reject</button>
+                        </div>
+                    </form>
+                    <div class="alert alert-info mb-0">
+                        Provide remarks when rejecting the request so the institution understands the reason.
+                    </div>
+                <?php else: ?>
+                    <p class="text-muted mb-0">This fund transfer has already been <?php echo sanitize($transfer['status']); ?>.</p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/event_staff_fund_transfers.php
+++ b/event_staff_fund_transfers.php
@@ -1,0 +1,168 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+
+require_login();
+require_role(['event_staff']);
+
+$user = current_user();
+$db = get_db_connection();
+
+if (!$user['event_id']) {
+    echo '<div class="alert alert-warning">No event assigned to your account. Please contact the event administrator.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$event_id = (int) $user['event_id'];
+$status_filter = (string) get_param('status', 'all');
+$institution_filter = (int) get_param('institution_id', 0);
+
+$statuses = [
+    'all' => 'All Statuses',
+    'pending' => 'Pending',
+    'approved' => 'Approved',
+    'rejected' => 'Rejected',
+];
+
+$stmt = $db->prepare('SELECT DISTINCT i.id, i.name FROM fund_transfers ft INNER JOIN institutions i ON i.id = ft.institution_id WHERE ft.event_id = ? ORDER BY i.name');
+$stmt->bind_param('i', $event_id);
+$stmt->execute();
+$institutions = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$sql = "SELECT ft.id, ft.transfer_date, ft.mode, ft.amount, ft.transaction_number, ft.status, ft.created_at, ft.reference_document_path,
+               i.name AS institution_name,
+               submitter.name AS submitted_by_name
+        FROM fund_transfers ft
+        INNER JOIN institutions i ON i.id = ft.institution_id
+        LEFT JOIN users submitter ON submitter.id = ft.submitted_by
+        WHERE ft.event_id = ?";
+$types = 'i';
+$params = [$event_id];
+
+if ($institution_filter > 0) {
+    $sql .= ' AND ft.institution_id = ?';
+    $types .= 'i';
+    $params[] = $institution_filter;
+}
+
+if ($status_filter !== 'all' && array_key_exists($status_filter, $statuses)) {
+    $sql .= ' AND ft.status = ?';
+    $types .= 's';
+    $params[] = $status_filter;
+}
+
+$sql .= ' ORDER BY ft.created_at DESC';
+
+$stmt = $db->prepare($sql);
+$stmt->bind_param($types, ...$params);
+$stmt->execute();
+$transfers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$flash_success = get_flash('success');
+$flash_error = get_flash('error');
+
+$status_classes = [
+    'pending' => 'warning',
+    'approved' => 'success',
+    'rejected' => 'danger',
+];
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0">Fund Transfer Requests</h1>
+        <p class="text-muted mb-0">Review and manage fund transfer submissions from participating institutions.</p>
+    </div>
+</div>
+
+<?php if ($flash_success): ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <?php echo sanitize($flash_success); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+<?php endif; ?>
+
+<?php if ($flash_error): ?>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <?php echo sanitize($flash_error); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+<?php endif; ?>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <form method="get" class="row g-3 align-items-end">
+            <div class="col-md-4">
+                <label for="institution_id" class="form-label">Participating Institution</label>
+                <select name="institution_id" id="institution_id" class="form-select">
+                    <option value="0">All Institutions</option>
+                    <?php foreach ($institutions as $institution): ?>
+                        <option value="<?php echo (int) $institution['id']; ?>" <?php echo $institution['id'] == $institution_filter ? 'selected' : ''; ?>>
+                            <?php echo sanitize($institution['name']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="status" class="form-label">Status</label>
+                <select name="status" id="status" class="form-select">
+                    <?php foreach ($statuses as $key => $label): ?>
+                        <option value="<?php echo $key; ?>" <?php echo $status_filter === $key ? 'selected' : ''; ?>><?php echo sanitize($label); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="col-md-4 d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Apply Filters</button>
+                <a href="event_staff_fund_transfers.php" class="btn btn-outline-secondary">Reset</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <?php if (!$transfers): ?>
+            <p class="text-muted mb-0">No fund transfer submissions match the selected filters.</p>
+        <?php else: ?>
+            <div class="table-responsive">
+                <table class="table table-striped align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">#</th>
+                            <th scope="col">Institution</th>
+                            <th scope="col">Submitted By</th>
+                            <th scope="col">Transfer Date</th>
+                            <th scope="col">Mode</th>
+                            <th scope="col" class="text-end">Amount (₹)</th>
+                            <th scope="col">Status</th>
+                            <th scope="col" class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($transfers as $index => $transfer): ?>
+                            <tr>
+                                <td><?php echo (int) ($index + 1); ?></td>
+                                <td><?php echo sanitize($transfer['institution_name']); ?></td>
+                                <td><?php echo sanitize($transfer['submitted_by_name'] ?? 'N/A'); ?></td>
+                                <td><?php echo sanitize(format_date($transfer['transfer_date'])); ?></td>
+                                <td><?php echo sanitize($transfer['mode']); ?></td>
+                                <td class="text-end">₹<?php echo number_format((float) $transfer['amount'], 2); ?></td>
+                                <td>
+                                    <span class="badge bg-<?php echo $status_classes[$transfer['status']] ?? 'secondary'; ?> text-uppercase">
+                                        <?php echo sanitize($transfer['status']); ?>
+                                    </span>
+                                </td>
+                                <td class="text-end">
+                                    <a href="event_staff_fund_transfer_view.php?transfer_id=<?php echo (int) $transfer['id']; ?>" class="btn btn-sm btn-outline-primary">View Details</a>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -26,9 +26,11 @@
                 <?php endif; ?>
                 <?php if ($user['role'] === 'institution_admin'): ?>
                     <li class="nav-item"><a class="nav-link" href="participants.php">Participants</a></li>
+                    <li class="nav-item"><a class="nav-link" href="institution_fund_transfers.php">Fund Transfers</a></li>
                 <?php endif; ?>
                 <?php if ($user['role'] === 'event_staff'): ?>
                     <li class="nav-item"><a class="nav-link" href="event_staff_participants.php">Participants</a></li>
+                    <li class="nav-item"><a class="nav-link" href="event_staff_fund_transfers.php">Fund Transfers</a></li>
                 <?php endif; ?>
             </ul>
             <div class="dropdown">

--- a/institution_approved_report.php
+++ b/institution_approved_report.php
@@ -42,6 +42,12 @@ $stmt->execute();
 $participants = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
 $stmt->close();
 
+$stmt = $db->prepare('SELECT transfer_date, mode, amount, transaction_number, status, reviewed_at FROM fund_transfers WHERE institution_id = ? ORDER BY transfer_date DESC, created_at DESC');
+$stmt->bind_param('i', $institution_id);
+$stmt->execute();
+$fund_transfers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
 $age_categories = fetch_age_categories($db);
 $report_date = date('d M Y H:i');
 $total_events_sum = 0;
@@ -163,6 +169,9 @@ unset($participant);
             body {
                 margin: 10mm;
             }
+            .page-break {
+                page-break-before: always;
+            }
         }
     </style>
 </head>
@@ -225,6 +234,40 @@ unset($participant);
         <?php else: ?>
             <tr>
                 <td colspan="9" style="text-align:center; padding:24px; color:#6c757d;">No approved participants found.</td>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+    </table>
+    <div class="page-break"></div>
+    <h2 style="margin-top:32px; margin-bottom:16px;">Fund Transfer Submissions</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Sl. No</th>
+                <th>Transfer Date</th>
+                <th>Mode</th>
+                <th>Amount (₹)</th>
+                <th>Transaction Number</th>
+                <th>Status</th>
+                <th>Reviewed On</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if ($fund_transfers): ?>
+            <?php foreach ($fund_transfers as $index => $transfer): ?>
+                <tr>
+                    <td><?php echo $index + 1; ?></td>
+                    <td><?php echo $transfer['transfer_date'] ? sanitize(date('d M Y', strtotime($transfer['transfer_date']))) : '<span style="color:#6c757d;">N/A</span>'; ?></td>
+                    <td><?php echo sanitize($transfer['mode']); ?></td>
+                    <td>₹<?php echo number_format((float) $transfer['amount'], 2); ?></td>
+                    <td><?php echo sanitize($transfer['transaction_number']); ?></td>
+                    <td style="text-transform:uppercase;"><strong><?php echo sanitize($transfer['status']); ?></strong></td>
+                    <td><?php echo $transfer['reviewed_at'] ? sanitize(date('d M Y', strtotime($transfer['reviewed_at']))) : '<span style="color:#6c757d;">Pending</span>'; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <tr>
+                <td colspan="7" style="text-align:center; padding:24px; color:#6c757d;">No fund transfers have been submitted.</td>
             </tr>
         <?php endif; ?>
         </tbody>

--- a/institution_fund_transfers.php
+++ b/institution_fund_transfers.php
@@ -1,0 +1,295 @@
+<?php
+$page_title = 'Fund Transfer Submissions';
+require_once __DIR__ . '/includes/header.php';
+
+require_login();
+require_role(['institution_admin']);
+
+$user = current_user();
+$db = get_db_connection();
+
+if (!$user['institution_id']) {
+    echo '<div class="alert alert-warning">No institution assigned to your account. Please contact the event administrator.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$institution_id = (int) $user['institution_id'];
+$stmt = $db->prepare('SELECT id, name, event_id FROM institutions WHERE id = ? LIMIT 1');
+$stmt->bind_param('i', $institution_id);
+$stmt->execute();
+$institution = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+
+if (!$institution) {
+    echo '<div class="alert alert-danger">Unable to locate institution details.</div>';
+    include __DIR__ . '/includes/footer.php';
+    return;
+}
+
+$event_id = (int) $institution['event_id'];
+$errors = [];
+$form_values = [
+    'transfer_date' => date('Y-m-d'),
+    'mode' => 'NEFT',
+    'amount' => '',
+    'transaction_number' => '',
+];
+
+function handle_reference_upload(?array $file, array &$errors): ?string
+{
+    if (!$file || ($file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE) {
+        $errors['reference_document'] = 'Reference document is required.';
+        return null;
+    }
+
+    if (($file['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
+        $errors['reference_document'] = 'Failed to upload the reference document.';
+        return null;
+    }
+
+    $allowed_mimes = [
+        'application/pdf' => 'pdf',
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+    ];
+
+    $finfo = finfo_open(FILEINFO_MIME_TYPE);
+    $mime = $finfo ? finfo_file($finfo, $file['tmp_name']) : null;
+    if ($finfo) {
+        finfo_close($finfo);
+    }
+
+    if (!$mime || !array_key_exists($mime, $allowed_mimes)) {
+        $errors['reference_document'] = 'The reference document must be a PDF or image (JPG/PNG).';
+        return null;
+    }
+
+    if (($file['size'] ?? 0) > 5 * 1024 * 1024) {
+        $errors['reference_document'] = 'Reference document must be smaller than 5MB.';
+        return null;
+    }
+
+    $extension = $allowed_mimes[$mime];
+    $upload_dir = __DIR__ . '/uploads/fund_transfers';
+    if (!is_dir($upload_dir) && !mkdir($upload_dir, 0777, true) && !is_dir($upload_dir)) {
+        $errors['reference_document'] = 'Unable to prepare the upload directory.';
+        return null;
+    }
+
+    try {
+        $random = bin2hex(random_bytes(5));
+    } catch (Throwable $e) {
+        $random = uniqid('', true);
+    }
+
+    $filename = 'fund_' . time() . '_' . preg_replace('/[^a-zA-Z0-9_\-\.]/', '', $random) . '.' . $extension;
+    $destination = $upload_dir . '/' . $filename;
+
+    if (!move_uploaded_file($file['tmp_name'], $destination)) {
+        $errors['reference_document'] = 'Failed to save the uploaded document.';
+        return null;
+    }
+
+    return 'uploads/fund_transfers/' . $filename;
+}
+
+if (is_post()) {
+    $form_values = [
+        'transfer_date' => trim((string) post_param('transfer_date', '')),
+        'mode' => trim((string) post_param('mode', '')),
+        'amount' => trim((string) post_param('amount', '')),
+        'transaction_number' => trim((string) post_param('transaction_number', '')),
+    ];
+
+    validate_required([
+        'transfer_date' => 'Transfer date',
+        'mode' => 'Mode of transfer',
+        'amount' => 'Amount transferred',
+        'transaction_number' => 'Transaction number',
+    ], $errors, $form_values);
+
+    $modes = ['NEFT', 'UPI', 'Other'];
+    if ($form_values['mode'] && !in_array($form_values['mode'], $modes, true)) {
+        $errors['mode'] = 'Invalid mode selected.';
+    }
+
+    $transfer_date = null;
+    if ($form_values['transfer_date']) {
+        $date = DateTime::createFromFormat('Y-m-d', $form_values['transfer_date']);
+        if ($date && $date->format('Y-m-d') === $form_values['transfer_date']) {
+            $transfer_date = $date->format('Y-m-d');
+        } else {
+            $errors['transfer_date'] = 'Please provide a valid transfer date.';
+        }
+    }
+
+    $amount = null;
+    if ($form_values['amount'] !== '') {
+        $amount = filter_var($form_values['amount'], FILTER_VALIDATE_FLOAT);
+        if ($amount === false || $amount <= 0) {
+            $errors['amount'] = 'Amount must be a positive number.';
+        }
+    }
+
+    $document_path = null;
+    if (!$errors) {
+        $document_path = handle_reference_upload($_FILES['reference_document'] ?? null, $errors);
+    }
+
+    if (!$errors && $transfer_date && $amount !== null && $document_path) {
+        $stmt = $db->prepare('INSERT INTO fund_transfers (event_id, institution_id, submitted_by, transfer_date, mode, amount, transaction_number, reference_document_path, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, "pending")');
+        $submitted_by = (int) $user['id'];
+        $transaction_number = $form_values['transaction_number'];
+        $mode = $form_values['mode'];
+        $stmt->bind_param('iiissdss', $event_id, $institution_id, $submitted_by, $transfer_date, $mode, $amount, $transaction_number, $document_path);
+        $stmt->execute();
+        $stmt->close();
+
+        set_flash('success', 'Fund transfer submitted successfully for verification.');
+        redirect('institution_fund_transfers.php');
+    }
+}
+
+$success_message = get_flash('success');
+
+$stmt = $db->prepare('SELECT ft.id, ft.transfer_date, ft.mode, ft.amount, ft.transaction_number, ft.status, ft.reference_document_path, ft.created_at, ft.remarks, ft.reviewed_at, u.name AS reviewed_by_name
+    FROM fund_transfers ft
+    LEFT JOIN users u ON u.id = ft.reviewed_by
+    WHERE ft.institution_id = ?
+    ORDER BY ft.created_at DESC');
+$stmt->bind_param('i', $institution_id);
+$stmt->execute();
+$transfers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+$status_classes = [
+    'pending' => 'warning',
+    'approved' => 'success',
+    'rejected' => 'danger',
+];
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h4 mb-0">Fund Transfer Submissions</h1>
+        <p class="text-muted mb-0">Submit transfer details for the institution: <?php echo sanitize($institution['name']); ?>.</p>
+    </div>
+</div>
+
+<?php if ($success_message): ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <?php echo sanitize($success_message); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+<?php endif; ?>
+
+<?php if ($errors): ?>
+    <div class="alert alert-danger">
+        <strong>Unable to submit the fund transfer.</strong>
+        <ul class="mb-0 mt-2">
+            <?php foreach ($errors as $message): ?>
+                <li><?php echo sanitize($message); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+
+<div class="row g-4 mb-4">
+    <div class="col-lg-5">
+        <div class="card shadow-sm h-100">
+            <div class="card-header bg-white">
+                <h2 class="h6 mb-0">New Fund Transfer</h2>
+            </div>
+            <div class="card-body">
+                <form method="post" enctype="multipart/form-data" novalidate>
+                    <div class="mb-3">
+                        <label for="transfer_date" class="form-label">Date of Fund Transfer</label>
+                        <input type="date" name="transfer_date" id="transfer_date" class="form-control" value="<?php echo sanitize($form_values['transfer_date']); ?>" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="mode" class="form-label">Mode of Transfer</label>
+                        <select name="mode" id="mode" class="form-select" required>
+                            <?php foreach (['NEFT', 'UPI', 'Other'] as $mode_option): ?>
+                                <option value="<?php echo $mode_option; ?>" <?php echo $form_values['mode'] === $mode_option ? 'selected' : ''; ?>><?php echo $mode_option; ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="amount" class="form-label">Amount Transferred (₹)</label>
+                        <input type="number" step="0.01" min="0" name="amount" id="amount" class="form-control" value="<?php echo sanitize($form_values['amount']); ?>" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="transaction_number" class="form-label">Transaction Number</label>
+                        <input type="text" name="transaction_number" id="transaction_number" class="form-control" value="<?php echo sanitize($form_values['transaction_number']); ?>" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="reference_document" class="form-label">Upload Reference Document</label>
+                        <input type="file" name="reference_document" id="reference_document" class="form-control" accept=".pdf,.jpg,.jpeg,.png" required>
+                        <div class="form-text">Accepted formats: PDF, JPG, PNG. Max size 5MB.</div>
+                    </div>
+                    <div class="d-grid">
+                        <button type="submit" class="btn btn-primary">Submit Transfer Details</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-7">
+        <div class="card shadow-sm h-100">
+            <div class="card-header bg-white">
+                <h2 class="h6 mb-0">Submission History</h2>
+            </div>
+            <div class="card-body">
+                <?php if (!$transfers): ?>
+                    <p class="text-muted mb-0">No fund transfer submissions have been recorded yet.</p>
+                <?php else: ?>
+                    <div class="table-responsive">
+                        <table class="table table-striped align-middle">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Date</th>
+                                    <th scope="col">Mode</th>
+                                    <th scope="col" class="text-end">Amount (₹)</th>
+                                    <th scope="col">Transaction No.</th>
+                                    <th scope="col">Status</th>
+                                    <th scope="col" class="text-end">Reference</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($transfers as $transfer): ?>
+                                    <tr>
+                                        <td><?php echo sanitize(format_date($transfer['transfer_date'])); ?></td>
+                                        <td><?php echo sanitize($transfer['mode']); ?></td>
+                                        <td class="text-end">₹<?php echo number_format((float) $transfer['amount'], 2); ?></td>
+                                        <td><?php echo sanitize($transfer['transaction_number']); ?></td>
+                                        <td>
+                                            <span class="badge bg-<?php echo $status_classes[$transfer['status']] ?? 'secondary'; ?> text-uppercase">
+                                                <?php echo sanitize($transfer['status']); ?>
+                                            </span>
+                                            <?php if ($transfer['status'] !== 'pending' && $transfer['reviewed_at']): ?>
+                                                <div class="small text-muted">
+                                                    <?php echo sanitize('Reviewed on ' . format_date($transfer['reviewed_at'])); ?>
+                                                    <?php if ($transfer['reviewed_by_name']): ?>
+                                                        <br><span>By <?php echo sanitize($transfer['reviewed_by_name']); ?></span>
+                                                    <?php endif; ?>
+                                                </div>
+                                            <?php endif; ?>
+                                            <?php if ($transfer['remarks']): ?>
+                                                <div class="small text-muted">Remarks: <?php echo sanitize($transfer['remarks']); ?></div>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td class="text-end">
+                                            <a href="<?php echo sanitize($transfer['reference_document_path']); ?>" target="_blank" class="btn btn-sm btn-outline-secondary">View</a>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/schema.sql
+++ b/schema.sql
@@ -107,6 +107,28 @@ CREATE TABLE participant_events (
     CONSTRAINT fk_participant_events_institution FOREIGN KEY (institution_id) REFERENCES institutions(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE fund_transfers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    event_id INT NOT NULL,
+    institution_id INT NOT NULL,
+    submitted_by INT NOT NULL,
+    transfer_date DATE NOT NULL,
+    mode ENUM('NEFT', 'UPI', 'Other') NOT NULL,
+    amount DECIMAL(12,2) NOT NULL,
+    transaction_number VARCHAR(120) NOT NULL,
+    reference_document_path VARCHAR(255) NOT NULL,
+    status ENUM('pending', 'approved', 'rejected') NOT NULL DEFAULT 'pending',
+    remarks TEXT,
+    reviewed_by INT DEFAULT NULL,
+    reviewed_at TIMESTAMP NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_fund_transfers_event FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+    CONSTRAINT fk_fund_transfers_institution FOREIGN KEY (institution_id) REFERENCES institutions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_fund_transfers_submitted_by FOREIGN KEY (submitted_by) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_fund_transfers_reviewed_by FOREIGN KEY (reviewed_by) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Default super administrator (password: admin123)
 INSERT INTO users (name, email, password_hash, role)
 VALUES ('Super Admin', 'admin@sportsmis.test', '$2y$12$trU5SxG4m7i1INbCwSkUrOeIjll/RGdg6o/P4qNJDiGqwy4D1ew8O', 'super_admin');


### PR DESCRIPTION
## Summary
- define a `fund_transfers` table to persist institution payments and review metadata
- add institution admin tooling to submit transfer details with document upload and view submission history
- provide event staff pages to review, approve, or reject transfers and surface transfer data in the approved participants report and navigation

## Testing
- php -l institution_fund_transfers.php
- php -l event_staff_fund_transfers.php
- php -l event_staff_fund_transfer_view.php
- php -l institution_approved_report.php
- php -l includes/navbar.php

------
https://chatgpt.com/codex/tasks/task_e_68d59067b1b083319f2eb0bc23f65f5d