### PR TITLE
Refine team entry workflow and filter participant events

### DIFF
--- a/event_staff_participants.php
+++ b/event_staff_participants.php
@@ -32,11 +32,12 @@ $types = 'i';
 $params = [$assigned_event_id];
 $sql = "SELECT p.id, p.name, p.gender, p.contact_number, p.status, p.chest_number,
                i.name AS institution_name,
-               COUNT(pe.id) AS event_count,
-               COALESCE(SUM(pe.fees), 0) AS total_fees
+               COUNT(CASE WHEN em.event_type = 'Individual' THEN pe.id END) AS event_count,
+               COALESCE(SUM(CASE WHEN em.event_type = 'Individual' THEN pe.fees ELSE 0 END), 0) AS total_fees
         FROM participants p
         LEFT JOIN institutions i ON i.id = p.institution_id
         LEFT JOIN participant_events pe ON pe.participant_id = p.id
+        LEFT JOIN event_master em ON em.id = pe.event_master_id
         WHERE p.event_id = ?";
 
 if ($selected_institution_id > 0) {

--- a/event_staff_team_entries.php
+++ b/event_staff_team_entries.php
@@ -69,7 +69,7 @@ $institutions = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
 $stmt->close();
 
 $sql = 'SELECT te.id, te.team_name, te.status, te.submitted_at, te.reviewed_at, i.name AS institution_name,
-               em.name AS event_name, em.code, em.label,
+               em.name AS event_name, em.code, em.label, em.fees,
                u1.name AS submitted_by_name, u2.name AS reviewed_by_name
         FROM team_entries te
         JOIN institutions i ON i.id = te.institution_id
@@ -193,6 +193,7 @@ $error_message = get_flash('error');
                             <th>Team</th>
                             <th>Institution</th>
                             <th>Event</th>
+                            <th class="text-end">Fees (₹)</th>
                             <th>Participants</th>
                             <th>Status</th>
                             <th class="text-end">Actions</th>
@@ -210,6 +211,7 @@ $error_message = get_flash('error');
                                     <div class="fw-semibold"><?php echo sanitize($entry['event_name']); ?></div>
                                     <div class="text-muted small"><?php echo sanitize($entry['code']); ?><?php if (!empty($entry['label'])): ?> &middot; <?php echo sanitize($entry['label']); ?><?php endif; ?></div>
                                 </td>
+                                <td class="text-end">₹<?php echo number_format((float) ($entry['fees'] ?? 0), 2); ?></td>
                                 <td>
                                     <?php $members = $team_members[$entry['id']] ?? []; ?>
                                     <?php if ($members): ?>

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -26,6 +26,7 @@
                 <?php endif; ?>
                 <?php if ($user['role'] === 'institution_admin'): ?>
                     <li class="nav-item"><a class="nav-link" href="participants.php">Participants</a></li>
+                    <li class="nav-item"><a class="nav-link" href="institution_approved_report.php" target="_blank">Approved Participants Report</a></li>
                     <li class="nav-item"><a class="nav-link" href="institution_team_entries.php">Team Entries</a></li>
                     <li class="nav-item"><a class="nav-link" href="institution_event_registrations.php">Institution Events</a></li>
                     <li class="nav-item"><a class="nav-link" href="institution_fund_transfers.php">Fund Transfers</a></li>

--- a/participant_competitor_card.php
+++ b/participant_competitor_card.php
@@ -71,7 +71,7 @@ $participant_age = calculate_age($participant['date_of_birth']);
 $age_categories = fetch_age_categories($db);
 $participant_age_category = determine_age_category_label($participant_age, $age_categories);
 
-$stmt = $db->prepare('SELECT em.name, em.code, em.event_type, ac.name AS age_category_name FROM participant_events pe JOIN event_master em ON em.id = pe.event_master_id JOIN age_categories ac ON ac.id = em.age_category_id WHERE pe.participant_id = ? ORDER BY em.name');
+$stmt = $db->prepare("SELECT em.name, em.code, em.event_type, ac.name AS age_category_name\n    FROM participant_events pe\n    JOIN event_master em ON em.id = pe.event_master_id\n    JOIN age_categories ac ON ac.id = em.age_category_id\n    WHERE pe.participant_id = ? AND em.event_type = 'Individual'\n    ORDER BY em.name");
 $stmt->bind_param('i', $participant_id);
 $stmt->execute();
 $assigned_events = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);

--- a/participant_events.php
+++ b/participant_events.php
@@ -112,7 +112,7 @@ if (is_post()) {
             set_flash('error', 'Select an event to add.');
             redirect('participant_events.php?participant_id=' . $participant_id);
         }
-        $stmt = $db->prepare('SELECT em.*, ac.min_age, ac.max_age FROM event_master em JOIN age_categories ac ON ac.id = em.age_category_id WHERE em.id = ? AND em.event_id = ?');
+        $stmt = $db->prepare("SELECT em.*, ac.min_age, ac.max_age\n            FROM event_master em\n            JOIN age_categories ac ON ac.id = em.age_category_id\n            WHERE em.id = ? AND em.event_id = ? AND em.event_type = 'Individual'");
         $stmt->bind_param('ii', $event_master_id, $participant['event_id']);
         $stmt->execute();
         $event_entry = $stmt->get_result()->fetch_assoc();
@@ -169,7 +169,7 @@ if (is_post()) {
     }
 }
 
-$stmt = $db->prepare('SELECT pe.id, pe.event_master_id, em.name, em.code, em.event_type, em.fees, em.label, ac.name AS age_category_name FROM participant_events pe JOIN event_master em ON em.id = pe.event_master_id JOIN age_categories ac ON ac.id = em.age_category_id WHERE pe.participant_id = ? ORDER BY em.name');
+$stmt = $db->prepare("SELECT pe.id, pe.event_master_id, em.name, em.code, em.event_type, em.fees, em.label, ac.name AS age_category_name\n    FROM participant_events pe\n    JOIN event_master em ON em.id = pe.event_master_id\n    JOIN age_categories ac ON ac.id = em.age_category_id\n    WHERE pe.participant_id = ? AND em.event_type = 'Individual'\n    ORDER BY em.name");
 $stmt->bind_param('i', $participant_id);
 $stmt->execute();
 $assigned_events = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
@@ -177,7 +177,7 @@ $stmt->close();
 
 $assigned_ids = array_map(static fn($row) => (int) $row['event_master_id'], $assigned_events);
 
-$stmt = $db->prepare('SELECT em.id, em.name, em.code, em.gender, em.event_type, em.fees, em.label, ac.name AS age_category_name, ac.min_age, ac.max_age FROM event_master em JOIN age_categories ac ON ac.id = em.age_category_id WHERE em.event_id = ? ORDER BY em.name');
+$stmt = $db->prepare("SELECT em.id, em.name, em.code, em.gender, em.event_type, em.fees, em.label, ac.name AS age_category_name, ac.min_age, ac.max_age\n    FROM event_master em\n    JOIN age_categories ac ON ac.id = em.age_category_id\n    WHERE em.event_id = ? AND em.event_type = 'Individual'\n    ORDER BY em.name");
 $stmt->bind_param('i', $participant['event_id']);
 $stmt->execute();
 $all_events = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);

--- a/participant_view.php
+++ b/participant_view.php
@@ -61,7 +61,7 @@ $participant_age = calculate_age($participant['date_of_birth']);
 $age_categories = fetch_age_categories($db);
 $participant_age_category = determine_age_category_label($participant_age, $age_categories);
 
-$stmt = $db->prepare('SELECT pe.id, em.name, em.code, em.label, em.event_type, em.fees, ac.name AS age_category_name FROM participant_events pe JOIN event_master em ON em.id = pe.event_master_id JOIN age_categories ac ON ac.id = em.age_category_id WHERE pe.participant_id = ? ORDER BY em.name');
+$stmt = $db->prepare("SELECT pe.id, em.name, em.code, em.label, em.event_type, em.fees, ac.name AS age_category_name\n    FROM participant_events pe\n    JOIN event_master em ON em.id = pe.event_master_id\n    JOIN age_categories ac ON ac.id = em.age_category_id\n    WHERE pe.participant_id = ? AND em.event_type = 'Individual'\n    ORDER BY em.name");
 $stmt->bind_param('i', $participant_id);
 $stmt->execute();
 $assigned_events = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);

--- a/participants.php
+++ b/participants.php
@@ -102,7 +102,7 @@ if (is_post() && $can_manage) {
     }
 }
 
-$statsSubquery = 'SELECT participant_id, COUNT(*) AS total_events, COALESCE(SUM(fees), 0) AS total_fees FROM participant_events GROUP BY participant_id';
+$statsSubquery = "SELECT pe.participant_id, COUNT(*) AS total_events, COALESCE(SUM(pe.fees), 0) AS total_fees\n    FROM participant_events pe\n    INNER JOIN event_master em ON em.id = pe.event_master_id AND em.event_type = 'Individual'\n    GROUP BY pe.participant_id";
 $sql = "SELECT p.id, p.institution_id, p.event_id, p.name, p.email, p.date_of_birth, p.gender, p.guardian_name, p.contact_number, p.status, p.chest_number, i.name AS institution_name, COALESCE(stats.total_events, 0) AS total_events, COALESCE(stats.total_fees, 0) AS total_fees FROM participants p LEFT JOIN institutions i ON i.id = p.institution_id LEFT JOIN ($statsSubquery) stats ON stats.participant_id = p.id";
 $conditions = [];
 $params = [];


### PR DESCRIPTION
## Summary
- restrict participant event assignments and related statistics to individual events only
- redesign the team entry flow to capture team metadata, show fees, and manage members with a selectable list
- display team-event fees in listings and reports while adding a navbar shortcut to the approved participants report

## Testing
- php -l event_staff_participant_view.php event_staff_participants.php event_staff_team_entries.php includes/navbar.php institution_approved_report.php institution_team_entries.php participant_competitor_card.php participant_events.php participant_view.php participants.php

------
https://chatgpt.com/codex/tasks/task_e_68d8c12476888331b23da7c7a6e12a16