### PR TITLE
Add event payment configuration and move approvals to event staff

### DIFF
--- a/event_settings.php
+++ b/event_settings.php
@@ -15,6 +15,7 @@ if (!$user['event_id']) {
 $event_id = (int) $user['event_id'];
 $errors = [];
 $success = null;
+$delete_qr_path = null;
 
 $stmt = $db->prepare('SELECT * FROM events WHERE id = ?');
 $stmt->bind_param('i', $event_id);
@@ -34,15 +35,106 @@ if (is_post()) {
     $event['start_date'] = post_param('start_date') ?: null;
     $event['end_date'] = post_param('end_date') ?: null;
     $event['description'] = trim((string) post_param('description', $event['description']));
+    $event['bank_account_number'] = trim((string) post_param('bank_account_number', (string) ($event['bank_account_number'] ?? '')));
+    $event['bank_ifsc'] = trim((string) post_param('bank_ifsc', (string) ($event['bank_ifsc'] ?? '')));
+    $event['bank_name'] = trim((string) post_param('bank_name', (string) ($event['bank_name'] ?? '')));
+
+    $remove_qr = (string) post_param('remove_qr', '') === '1';
+
+    if ($event['bank_account_number'] === '') {
+        $event['bank_account_number'] = null;
+    }
+    if ($event['bank_ifsc'] === '') {
+        $event['bank_ifsc'] = null;
+    }
+    if ($event['bank_name'] === '') {
+        $event['bank_name'] = null;
+    }
 
     validate_required(['name' => 'Event name'], $errors, $event);
 
+    $qr_upload = $_FILES['payment_qr'] ?? null;
+    $qr_ready_for_save = false;
+    $qr_extension = null;
+
+    if ($qr_upload && ($qr_upload['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_NO_FILE) {
+        if (($qr_upload['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
+            $errors['payment_qr'] = 'Failed to upload the QR code image.';
+        } else {
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+            $mime = $finfo ? finfo_file($finfo, $qr_upload['tmp_name']) : null;
+            if ($finfo) {
+                finfo_close($finfo);
+            }
+
+            $allowed_mimes = [
+                'image/jpeg' => 'jpg',
+                'image/png' => 'png',
+                'image/webp' => 'webp',
+            ];
+
+            if (!$mime || !array_key_exists($mime, $allowed_mimes)) {
+                $errors['payment_qr'] = 'QR code image must be a JPG, PNG, or WEBP file.';
+            } elseif (($qr_upload['size'] ?? 0) > 5 * 1024 * 1024) {
+                $errors['payment_qr'] = 'QR code image must be smaller than 5MB.';
+            } else {
+                $qr_extension = $allowed_mimes[$mime];
+                $qr_ready_for_save = true;
+            }
+        }
+    }
+
     if (!$errors) {
-        $stmt = $db->prepare('UPDATE events SET name = ?, location = ?, start_date = ?, end_date = ?, description = ? WHERE id = ?');
-        $stmt->bind_param('sssssi', $event['name'], $event['location'], $event['start_date'], $event['end_date'], $event['description'], $event_id);
+        if ($qr_ready_for_save) {
+            $upload_dir = __DIR__ . '/uploads/event_payments';
+            if (!is_dir($upload_dir) && !mkdir($upload_dir, 0777, true) && !is_dir($upload_dir)) {
+                $errors['payment_qr'] = 'Unable to prepare the directory for QR code uploads.';
+            } else {
+                try {
+                    $random = bin2hex(random_bytes(8));
+                } catch (Throwable $e) {
+                    $random = uniqid('', true);
+                }
+                $filename = 'qr_' . time() . '_' . $random . '.' . $qr_extension;
+                $destination = $upload_dir . '/' . $filename;
+                if (!move_uploaded_file($qr_upload['tmp_name'], $destination)) {
+                    $errors['payment_qr'] = 'Failed to save the QR code image.';
+                } else {
+                    $delete_qr_path = $event['payment_qr_path'] ?? null;
+                    $event['payment_qr_path'] = 'uploads/event_payments/' . $filename;
+                }
+            }
+        } elseif ($remove_qr && !empty($event['payment_qr_path'])) {
+            $delete_qr_path = $event['payment_qr_path'];
+            $event['payment_qr_path'] = null;
+        }
+    }
+
+    if (!$errors) {
+        $stmt = $db->prepare('UPDATE events SET name = ?, location = ?, start_date = ?, end_date = ?, description = ?, bank_account_number = ?, bank_ifsc = ?, bank_name = ?, payment_qr_path = ? WHERE id = ?');
+        $stmt->bind_param(
+            'sssssssssi',
+            $event['name'],
+            $event['location'],
+            $event['start_date'],
+            $event['end_date'],
+            $event['description'],
+            $event['bank_account_number'],
+            $event['bank_ifsc'],
+            $event['bank_name'],
+            $event['payment_qr_path'],
+            $event_id
+        );
         $stmt->execute();
         $stmt->close();
         $success = 'Event details updated successfully.';
+
+        if ($delete_qr_path && $delete_qr_path !== ($event['payment_qr_path'] ?? null)) {
+            $file = __DIR__ . '/' . ltrim($delete_qr_path, '/');
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
     }
 }
 ?>
@@ -56,7 +148,7 @@ if (is_post()) {
                 <?php if ($success): ?>
                     <div class="alert alert-success"><?php echo sanitize($success); ?></div>
                 <?php endif; ?>
-                <form method="post">
+                <form method="post" enctype="multipart/form-data">
                     <div class="mb-3">
                         <label for="name" class="form-label">Event Name</label>
                         <input type="text" class="form-control <?php echo isset($errors['name']) ? 'is-invalid' : ''; ?>" id="name" name="name" value="<?php echo sanitize($event['name']); ?>" required>
@@ -79,6 +171,37 @@ if (is_post()) {
                     <div class="mb-3">
                         <label for="description" class="form-label">Description</label>
                         <textarea class="form-control" id="description" name="description" rows="4"><?php echo sanitize($event['description']); ?></textarea>
+                    </div>
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label for="bank_account_number" class="form-label">Bank Account Number</label>
+                            <input type="text" class="form-control" id="bank_account_number" name="bank_account_number" value="<?php echo sanitize((string) ($event['bank_account_number'] ?? '')); ?>">
+                            <div class="form-text">Provide the account number for fee payments.</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="bank_ifsc" class="form-label">IFSC Code</label>
+                            <input type="text" class="form-control" id="bank_ifsc" name="bank_ifsc" value="<?php echo sanitize((string) ($event['bank_ifsc'] ?? '')); ?>">
+                        </div>
+                    </div>
+                    <div class="mb-3 mt-3">
+                        <label for="bank_name" class="form-label">Bank Name</label>
+                        <input type="text" class="form-control" id="bank_name" name="bank_name" value="<?php echo sanitize((string) ($event['bank_name'] ?? '')); ?>">
+                    </div>
+                    <div class="mb-3">
+                        <label for="payment_qr" class="form-label">Payment QR Code</label>
+                        <input type="file" class="form-control <?php echo isset($errors['payment_qr']) ? 'is-invalid' : ''; ?>" id="payment_qr" name="payment_qr" accept="image/png,image/jpeg,image/webp">
+                        <?php if (isset($errors['payment_qr'])): ?><div class="invalid-feedback"><?php echo sanitize($errors['payment_qr']); ?></div><?php else: ?><div class="form-text">Upload a QR image (PNG, JPG, WEBP, max 5MB).</div><?php endif; ?>
+                        <?php if (!empty($event['payment_qr_path'])): ?>
+                            <div class="mt-3">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" value="1" id="remove_qr" name="remove_qr">
+                                    <label class="form-check-label" for="remove_qr">Remove current QR code image</label>
+                                </div>
+                                <div class="mt-2">
+                                    <img src="<?php echo sanitize($event['payment_qr_path']); ?>" alt="Payment QR code" class="img-thumbnail" style="max-width: 200px;">
+                                </div>
+                            </div>
+                        <?php endif; ?>
                     </div>
                     <div class="d-grid">
                         <button type="submit" class="btn btn-primary">Save Settings</button>

--- a/event_staff_fund_transfer_view.php
+++ b/event_staff_fund_transfer_view.php
@@ -17,6 +17,12 @@ if (!$user['event_id']) {
 $event_id = (int) $user['event_id'];
 $transfer_id = (int) get_param('transfer_id', 0);
 
+$payment_stmt = $db->prepare('SELECT bank_account_number, bank_ifsc, bank_name, payment_qr_path FROM events WHERE id = ? LIMIT 1');
+$payment_stmt->bind_param('i', $event_id);
+$payment_stmt->execute();
+$event_payment = $payment_stmt->get_result()->fetch_assoc();
+$payment_stmt->close();
+
 if ($transfer_id <= 0) {
     echo '<div class="alert alert-danger">Invalid transfer reference provided.</div>';
     echo '<a href="event_staff_fund_transfers.php" class="btn btn-outline-secondary mt-3">Back to Fund Transfers</a>';
@@ -155,6 +161,48 @@ $status_classes = [
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
 <?php endif; ?>
+
+<?php
+$has_payment_details = $event_payment && (
+    !empty($event_payment['bank_account_number']) ||
+    !empty($event_payment['bank_ifsc']) ||
+    !empty($event_payment['bank_name']) ||
+    !empty($event_payment['payment_qr_path'])
+);
+?>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h6 mb-0">Payment Reference</h2>
+        <span class="badge bg-secondary">Share with Institution</span>
+    </div>
+    <div class="card-body">
+        <?php if ($has_payment_details): ?>
+            <div class="row g-4 align-items-center">
+                <div class="col-md-6">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-5">Bank Name</dt>
+                        <dd class="col-sm-7"><?php echo $event_payment['bank_name'] ? sanitize($event_payment['bank_name']) : '<span class="text-muted">Not provided</span>'; ?></dd>
+                        <dt class="col-sm-5">Account Number</dt>
+                        <dd class="col-sm-7"><?php echo $event_payment['bank_account_number'] ? sanitize($event_payment['bank_account_number']) : '<span class="text-muted">Not provided</span>'; ?></dd>
+                        <dt class="col-sm-5">IFSC</dt>
+                        <dd class="col-sm-7"><?php echo $event_payment['bank_ifsc'] ? sanitize($event_payment['bank_ifsc']) : '<span class="text-muted">Not provided</span>'; ?></dd>
+                    </dl>
+                </div>
+                <?php if (!empty($event_payment['payment_qr_path'])): ?>
+                    <div class="col-md-6 text-md-end">
+                        <div class="d-inline-block text-center">
+                            <img src="<?php echo sanitize($event_payment['payment_qr_path']); ?>" alt="Payment QR code" class="img-fluid rounded" style="max-width: 220px;">
+                            <div class="small text-muted mt-2">Verify the QR code against the submitted transfer.</div>
+                        </div>
+                    </div>
+                <?php endif; ?>
+            </div>
+        <?php else: ?>
+            <p class="mb-0 text-muted">Event payment account details have not been configured. Update the event settings to assist institutions.</p>
+        <?php endif; ?>
+    </div>
+</div>
 
 <div class="row g-4">
     <div class="col-lg-7">

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -26,14 +26,15 @@
                 <?php endif; ?>
                 <?php if ($user['role'] === 'institution_admin'): ?>
                     <li class="nav-item"><a class="nav-link" href="participants.php">Participants</a></li>
-                    <li class="nav-item"><a class="nav-link" href="institution_approved_report.php" target="_blank">Approved Participants Report</a></li>
                     <li class="nav-item"><a class="nav-link" href="institution_team_entries.php">Team Entries</a></li>
                     <li class="nav-item"><a class="nav-link" href="institution_event_registrations.php">Institution Events</a></li>
                     <li class="nav-item"><a class="nav-link" href="institution_fund_transfers.php">Fund Transfers</a></li>
+                    <li class="nav-item"><a class="nav-link" href="institution_approved_report.php" target="_blank">Approved Participants Report</a></li>
                 <?php endif; ?>
                 <?php if ($user['role'] === 'event_staff'): ?>
                     <li class="nav-item"><a class="nav-link" href="event_staff_participants.php">Participants</a></li>
                     <li class="nav-item"><a class="nav-link" href="event_staff_team_entries.php">Team Entries</a></li>
+                    <li class="nav-item"><a class="nav-link" href="institution_event_registrations.php">Institution Events</a></li>
                     <li class="nav-item"><a class="nav-link" href="event_staff_fund_transfers.php">Fund Transfers</a></li>
                 <?php endif; ?>
             </ul>

--- a/institution_event_registrations.php
+++ b/institution_event_registrations.php
@@ -3,7 +3,7 @@ $page_title = 'Institution Event Registrations';
 require_once __DIR__ . '/includes/header.php';
 
 require_login();
-require_role(['institution_admin', 'event_admin', 'super_admin']);
+require_role(['institution_admin', 'event_admin', 'event_staff', 'super_admin']);
 
 $user = current_user();
 $db = get_db_connection();
@@ -36,7 +36,7 @@ if ($role === 'institution_admin') {
     }
 
     $event_id = (int) $institution_context['event_id'];
-} elseif ($role === 'event_admin') {
+} elseif (in_array($role, ['event_admin', 'event_staff'], true)) {
     if (!$user['event_id']) {
         echo '<div class="alert alert-warning">No event assigned to your account. Please contact the super administrator.</div>';
         include __DIR__ . '/includes/footer.php';
@@ -82,7 +82,7 @@ $redirect_url = 'institution_event_registrations.php' . ($redirect_params ? '?' 
 
 $institution_options = [];
 
-if ($role === 'event_admin') {
+if (in_array($role, ['event_admin', 'event_staff'], true)) {
     $stmt = $db->prepare('SELECT id, name FROM institutions WHERE event_id = ? ORDER BY name');
     $stmt->bind_param('i', $event_id);
     $stmt->execute();
@@ -96,7 +96,7 @@ if ($role === 'event_admin') {
     }
 }
 
-if (($role === 'event_admin' || $role === 'super_admin') && !$institution_context) {
+if ((in_array($role, ['event_admin', 'event_staff'], true) || $role === 'super_admin') && !$institution_context) {
     echo '<div class="mb-4">';
     echo '<h1 class="h4 mb-2">Institution Event Registrations</h1>';
     echo '<p class="text-muted mb-3">Select an institution to review and manage its event registrations.</p>';
@@ -195,7 +195,7 @@ if (is_post()) {
         }
         redirect($redirect_url);
     } elseif ($action === 'update_status') {
-        if (!in_array($role, ['event_admin', 'super_admin'], true)) {
+        if (!in_array($role, ['event_staff', 'super_admin'], true)) {
             set_flash('error', 'You do not have permission to update approval status.');
             redirect($redirect_url);
         }
@@ -321,7 +321,7 @@ $error_message = get_flash('error');
         <div class="card shadow-sm">
             <div class="card-header bg-white d-flex justify-content-between align-items-center">
                 <h2 class="h6 mb-0">Registered Institution Events</h2>
-                <?php if (in_array($role, ['event_admin', 'super_admin'], true)): ?>
+                <?php if (in_array($role, ['event_staff', 'super_admin'], true)): ?>
                     <span class="badge bg-secondary">Approver Mode</span>
                 <?php endif; ?>
             </div>
@@ -384,7 +384,7 @@ $error_message = get_flash('error');
                                                 <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
                                             </form>
                                         <?php endif; ?>
-                                        <?php if (in_array($role, ['event_admin', 'super_admin'], true)): ?>
+                                        <?php if (in_array($role, ['event_staff', 'super_admin'], true)): ?>
                                             <form method="post" class="d-flex align-items-center gap-2">
                                                 <input type="hidden" name="action" value="update_status">
                                                 <input type="hidden" name="id" value="<?php echo (int) $registration['id']; ?>">

--- a/migrations/20240701_add_event_payment_fields.sql
+++ b/migrations/20240701_add_event_payment_fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE events
+    ADD COLUMN bank_account_number VARCHAR(60) NULL AFTER end_date,
+    ADD COLUMN bank_ifsc VARCHAR(20) NULL AFTER bank_account_number,
+    ADD COLUMN bank_name VARCHAR(150) NULL AFTER bank_ifsc,
+    ADD COLUMN payment_qr_path VARCHAR(255) NULL AFTER bank_name;

--- a/schema.sql
+++ b/schema.sql
@@ -7,6 +7,10 @@ CREATE TABLE events (
     location VARCHAR(150),
     start_date DATE,
     end_date DATE,
+    bank_account_number VARCHAR(60),
+    bank_ifsc VARCHAR(20),
+    bank_name VARCHAR(150),
+    payment_qr_path VARCHAR(255),
     created_by INT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary
- allow event administrators to capture bank account and QR code payment details with corresponding schema update and migration
- surface configured payment instructions on institution and event staff fund transfer pages
- shift institution event approvals to event staff, reorder navigation, and expand the institution dashboard with new metrics and fee summary

## Testing
- php -l event_settings.php
- php -l institution_fund_transfers.php
- php -l event_staff_fund_transfers.php
- php -l event_staff_fund_transfer_view.php
- php -l dashboard.php
- php -l institution_event_registrations.php
- php -l includes/navbar.php

------
https://chatgpt.com/codex/tasks/task_e_68d8cfe4edbc8331824c715861e0dca2